### PR TITLE
expose a `GcsClient` wrapper to julia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ deps/WORKSPACE.bazel
 deps/ray
 deps/bazel-*
 deps/override
+/.dir-locals.el

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ libcxxwrap_julia_jll = "0.9.7"
 [extras]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Serialization", "Test"]
+test = ["Serialization", "Test", "UUIDs"]

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -61,30 +61,30 @@ std::string ToString(ray::FunctionDescriptor function_descriptor)
 }
 
 JuliaGcsClient::JuliaGcsClient(const gcs::GcsClientOptions &options)
-  : options_(options) {
+    : options_(options) {
 }
 
 JuliaGcsClient::JuliaGcsClient(const std::string &gcs_address) {
-  options_ = gcs::GcsClientOptions(gcs_address);
+    options_ = gcs::GcsClientOptions(gcs_address);
 }
 
 Status JuliaGcsClient::Connect() {
-  gcs_client_ = std::make_unique<gcs::PythonGcsClient>(options_);
-  return gcs_client_->Connect();
+    gcs_client_ = std::make_unique<gcs::PythonGcsClient>(options_);
+    return gcs_client_->Connect();
 }
 
 std::string JuliaGcsClient::Get(const std::string &ns,
                                 const std::string &key,
                                 int64_t timeout_ms) {
-  if (!gcs_client_) {
-    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
-  }
-  std::string value;
-  Status status = gcs_client_->InternalKVGet(ns, key, timeout_ms, value);
-  if (!status.ok()) {
-    throw std::runtime_error(status.ToString());
-  }
-  return value;
+    if (!gcs_client_) {
+        throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+    }
+    std::string value;
+    Status status = gcs_client_->InternalKVGet(ns, key, timeout_ms, value);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+    return value;
 }
 
 int JuliaGcsClient::Put(const std::string &ns,
@@ -92,43 +92,43 @@ int JuliaGcsClient::Put(const std::string &ns,
                         const std::string &value,
                         bool overwrite,
                         int64_t timeout_ms) {
-  if (!gcs_client_) {
-    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
-  }
-  int added_num;
-  Status status = gcs_client_->InternalKVPut(ns, key, value, overwrite, timeout_ms, added_num);
-  if (!status.ok()) {
-    throw std::runtime_error(status.ToString());
-  }
-  return added_num;
+    if (!gcs_client_) {
+        throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+    }
+    int added_num;
+    Status status = gcs_client_->InternalKVPut(ns, key, value, overwrite, timeout_ms, added_num);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+    return added_num;
 }
 
 std::vector<std::string> JuliaGcsClient::Keys(const std::string &ns,
                                               const std::string &prefix,
                                               int64_t timeout_ms) {
-  if (!gcs_client_) {
-    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
-  }
-  std::vector<std::string> results;
-  Status status = gcs_client_->InternalKVKeys(ns, prefix, timeout_ms, results);
-  if (!status.ok()) {
-    throw std::runtime_error(status.ToString());
-  }
-  return results;
+    if (!gcs_client_) {
+        throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+    }
+    std::vector<std::string> results;
+    Status status = gcs_client_->InternalKVKeys(ns, prefix, timeout_ms, results);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+    return results;
 }
 
 bool JuliaGcsClient::Exists(const std::string &ns,
                             const std::string &key,
                             int64_t timeout_ms) {
-  if (!gcs_client_) {
-    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
-  }
-  bool exists;
-  Status status = gcs_client_->InternalKVExists(ns, key, timeout_ms, exists);
-  if (!status.ok()) {
-    throw std::runtime_error(status.ToString());
-  }
-  return exists;
+    if (!gcs_client_) {
+        throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+    }
+    bool exists;
+    Status status = gcs_client_->InternalKVExists(ns, key, timeout_ms, exists);
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+    return exists;
 }
 
 namespace jlcxx
@@ -183,7 +183,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // XXX: may not want these in the end, just for interactive testing of the
     // function descriptor stuff.
     mod.add_type<JuliaFunctionDescriptor>("JuliaFunctionDescriptor")
-      .method("ToString", &JuliaFunctionDescriptor::ToString);
+        .method("ToString", &JuliaFunctionDescriptor::ToString);
 
     // this is a typedef for shared_ptr<FunctionDescriptorInterface>...I wish I
     // could figure out how to de-reference this on the julia side but no dice so
@@ -215,14 +215,14 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     //                  bool>();
 
     mod.add_type<Status>("Status")
-      .method("ok", &Status::ok)
-      .method("ToString", &Status::ToString);
+        .method("ok", &Status::ok)
+        .method("ToString", &Status::ToString);
     mod.add_type<JuliaGcsClient>("JuliaGcsClient")
-      .constructor<const std::string&>()
-      .method("Connect", &JuliaGcsClient::Connect)
-      .method("Put", &JuliaGcsClient::Put)
-      .method("Get", &JuliaGcsClient::Get)
-      .method("Keys", &JuliaGcsClient::Keys)
-      .method("Exists", &JuliaGcsClient::Exists);
+        .constructor<const std::string&>()
+        .method("Connect", &JuliaGcsClient::Connect)
+        .method("Put", &JuliaGcsClient::Put)
+        .method("Get", &JuliaGcsClient::Get)
+        .method("Keys", &JuliaGcsClient::Keys)
+        .method("Exists", &JuliaGcsClient::Exists);
 }
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -103,16 +103,17 @@ void JuliaGcsClient::Disconnect() {
 
 std::string JuliaGcsClient::Get(const std::string &ns,
                                 const std::string &key) {
+  RAY_CHECK(gcs_client_);
   auto accessor = gcs_client_->InternalKV();
   std::string value;
   RAY_CHECK_OK(accessor.Get(ns, key, value));
-  // std::cout << "Got value: " << value << std::flush;
   return value;
 }
 
 void JuliaGcsClient::Put(const std::string &ns,
                          const std::string &key,
                          const std::string &value) {
+  RAY_CHECK(gcs_client_);
   auto accessor = gcs_client_->InternalKV();
   bool added;
   RAY_CHECK_OK(accessor.Put(ns, key, value, false, added));

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -103,7 +103,9 @@ void JuliaGcsClient::Disconnect() {
 
 std::string JuliaGcsClient::Get(const std::string &ns,
                                 const std::string &key) {
-  RAY_CHECK(gcs_client_);
+  if (!gcs_client_) {
+    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+  }
   auto accessor = gcs_client_->InternalKV();
   std::string value;
   RAY_CHECK_OK(accessor.Get(ns, key, value));
@@ -113,7 +115,9 @@ std::string JuliaGcsClient::Get(const std::string &ns,
 void JuliaGcsClient::Put(const std::string &ns,
                          const std::string &key,
                          const std::string &value) {
-  RAY_CHECK(gcs_client_);
+  if (!gcs_client_) {
+    throw std::runtime_error("GCS client not initialized; did you forget to Connect?");
+  }
   auto accessor = gcs_client_->InternalKV();
   bool added;
   RAY_CHECK_OK(accessor.Put(ns, key, value, false, added));

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -70,11 +70,9 @@ std::string ToString(ray::FunctionDescriptor function_descriptor)
 }
 
 JuliaGcsClient::JuliaGcsClient(const gcs::GcsClientOptions &options)
-  : options_(options), io_service_(nullptr) {}
+  : options_(options) {}
 
-JuliaGcsClient::JuliaGcsClient(const std::string &gcs_address)
-  : io_service_(nullptr)
-{
+JuliaGcsClient::JuliaGcsClient(const std::string &gcs_address) {
   options_ = gcs::GcsClientOptions(gcs_address);
 }
 
@@ -92,15 +90,12 @@ Status JuliaGcsClient::Connect() {
 
 void JuliaGcsClient::Disconnect() {
   if (io_service_) {
-    std::cout << "stopping io service..." << std::flush;
     io_service_->stop();
   }
-  if (io_service_thread_->joinable()) {
-    std::cout << "joining io service thread..." << std::flush;
+  if (io_service_thread_ && (io_service_thread_->joinable())) {
     io_service_thread_->join();
   }
   if (gcs_client_) {
-    std::cout << "disconnecting wrapped client..." << std::flush;
     gcs_client_->Disconnect();
     gcs_client_.reset();
   }

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -28,28 +28,28 @@ std::string ToString(ray::FunctionDescriptor function_descriptor);
 // not need this wrapper at all.
 class JuliaGcsClient {
 public:
-  JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
-  JuliaGcsClient(const std::string &gcs_address);
+    JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
+    JuliaGcsClient(const std::string &gcs_address);
 
-  ray::Status Connect();
+    ray::Status Connect();
 
-  std::string Get(const std::string &ns,
-                  const std::string &key,
-                  int64_t timeout_ms);
-  int Put(const std::string &ns,
-          const std::string &key,
-          const std::string &val,
-          bool overwrite,
-          int64_t timeout_ms);
-  std::vector<std::string> Keys(const std::string &ns,
-                                const std::string &prefix,
-                                int64_t timeout_ms);
-  bool Exists(const std::string &ns,
-              const std::string &key,
-              int64_t timeout_ms);
+    std::string Get(const std::string &ns,
+                    const std::string &key,
+                    int64_t timeout_ms);
+    int Put(const std::string &ns,
+            const std::string &key,
+            const std::string &val,
+            bool overwrite,
+            int64_t timeout_ms);
+    std::vector<std::string> Keys(const std::string &ns,
+                                  const std::string &prefix,
+                                  int64_t timeout_ms);
+    bool Exists(const std::string &ns,
+                const std::string &key,
+                int64_t timeout_ms);
 
-  std::unique_ptr<ray::gcs::PythonGcsClient> gcs_client_;
-  ray::gcs::GcsClientOptions options_;
+    std::unique_ptr<ray::gcs::PythonGcsClient> gcs_client_;
+    ray::gcs::GcsClientOptions options_;
 };
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod);

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -26,17 +26,14 @@ class JuliaGcsClient {
 public:
   JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
   JuliaGcsClient(const std::string &gcs_address);
-  ~JuliaGcsClient() { Disconnect(); };
 
   ray::Status Connect();
-  void Disconnect();
 
-  std::string Get(const std::string &ns, const std::string &key);
-  void Put(const std::string &ns, const std::string &key, const std::string &val);
+  std::string Get(const std::string &ns, const std::string &key, int64_t timeout_ms);
+  void Put(const std::string &ns, const std::string &key, const std::string &val,
+           bool overwrite, int64_t timeout_ms, int &added_num);
 
-  std::unique_ptr<ray::gcs::GcsClient> gcs_client_;
-  std::unique_ptr<instrumented_io_context> io_service_;
-  std::unique_ptr<std::thread> io_service_thread_;
+  std::unique_ptr<ray::gcs::PythonGcsClient> gcs_client_;
   ray::gcs::GcsClientOptions options_;
 };
 

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -6,6 +6,8 @@
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/core_worker.h"
 #include "src/ray/protobuf/common.pb.h"
+#include "ray/gcs/gcs_client/gcs_client.h"
+#include "ray/common/asio/instrumented_io_context.h"
 
 namespace julia {
 
@@ -15,6 +17,28 @@ ObjectID put(std::string str);
 std::string get(ObjectID object_id);
 
 std::string ToString(ray::FunctionDescriptor function_descriptor);
+
+// a wrapper class to manage the IO service + thread that the GcsClient needs.
+// we may want to use the PythonGcsClient however, which does not do async
+// operations in separate threads as far as I can tell...in which case we would
+// not need this wrapper at all.
+class JuliaGcsClient {
+public:
+  JuliaGcsClient(const ray::gcs::GcsClientOptions &options);
+  JuliaGcsClient(const std::string &gcs_address);
+  ~JuliaGcsClient() { Disconnect(); };
+
+  ray::Status Connect();
+  void Disconnect();
+
+  std::string Get(const std::string &ns, const std::string &key);
+  void Put(const std::string &ns, const std::string &key, const std::string &val);
+
+  std::unique_ptr<ray::gcs::GcsClient> gcs_client_;
+  std::unique_ptr<instrumented_io_context> io_service_;
+  std::unique_ptr<std::thread> io_service_thread_;
+  ray::gcs::GcsClientOptions options_;
+};
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod);
 

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -33,9 +33,20 @@ public:
 
   ray::Status Connect();
 
-  std::string Get(const std::string &ns, const std::string &key, int64_t timeout_ms);
-  void Put(const std::string &ns, const std::string &key, const std::string &val,
-           bool overwrite, int64_t timeout_ms, int &added_num);
+  std::string Get(const std::string &ns,
+                  const std::string &key,
+                  int64_t timeout_ms);
+  int Put(const std::string &ns,
+          const std::string &key,
+          const std::string &val,
+          bool overwrite,
+          int64_t timeout_ms);
+  std::vector<std::string> Keys(const std::string &ns,
+                                const std::string &prefix,
+                                int64_t timeout_ms);
+  bool Exists(const std::string &ns,
+              const std::string &key,
+              int64_t timeout_ms);
 
   std::unique_ptr<ray::gcs::PythonGcsClient> gcs_client_;
   ray::gcs::GcsClientOptions options_;

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -109,3 +109,4 @@ end
 
 Base.show(io::IO, fd::FunctionDescriptor) = print(io, ToString(fd))
 Base.show(io::IO, fd::JuliaFunctionDescriptor) = print(io, ToString(fd))
+Base.show(io::IO, status::Status) = print(io, ToString(status))

--- a/test/gcs_client.jl
+++ b/test/gcs_client.jl
@@ -1,0 +1,43 @@
+@testset "GCS client" begin
+    using ray_core_worker_julia_jll: Put, Get, Connect, JuliaGcsClient,
+                                     Status, ok, ToString
+
+    client = JuliaGcsClient("127.0.0.1:6379")
+    added = Ref{Cint}()
+
+    # throws if not connected
+    @test_throws ErrorException Put(client, "TESTING", "computer", "mistaek", false, -1, added)
+    @test_throws ErrorException Get(client, "TESTING", "computer", -1)
+
+    status = Connect(client)
+    @test ok(status)
+    @test ToString(status) == "OK"
+
+    @test Put(client, "TESTING", "computer", "mistaek", false, -1, added) === nothing
+    @test added[] == 1
+
+    @test Put(client, "TESTING", "computer", "mistaek", false, -1, added) === nothing
+    @test added[] == 0
+
+    @test Get(client, "TESTING", "computer", -1) == "mistaek"
+
+    # no overwrite
+    @test Put(client, "TESTING", "computer", "blah", false, -1, added) === nothing
+    @test Get(client, "TESTING", "computer", -1) == "mistaek"
+
+    # overwrite
+    @test Put(client, "TESTING", "computer", "blah", true, -1, added) === nothing
+    @test Get(client, "TESTING", "computer", -1) == "blah"
+    # added only increments on new key I think?
+    @test added[] == 0
+
+    # throw on missing key
+    @test_throws ErrorException Get(client, "TESTING", "none", -1)
+
+    # ideally we'd throw on connect but it returns OK......
+    badclient = JuliaGcsClient("127.0.0.1:6378")
+    status = Connect(badclient)
+
+    # ...but then throws when we try to do anything so at least there's that
+    @test_throws ErrorException Put(badclient, "TESTING", "computer", "mistaek", false, -1, added)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ include("utils.jl")
 
 @testset "ray_core_worker_julia_jll.jl" begin
     setup_ray_head_node() do
+        # GCS client only needs head node
+        include("gcs_client.jl")
         setup_core_worker() do
             include("put_get.jl")
             include("function_descriptor.jl")


### PR DESCRIPTION
Function manager will put/get stuff into the GCS internal key-value store, so a first step is being able to expose the KV store interface to julia.  Unfortunately this is not SO straightforward: the basic `GcsClient` needs a `io_service` (actually a `instrumented_io_service` but same thing basically) to manage the actual async execution of the requests, and the client that's embedded in the `CoreWorkerProcess` itself is private and not accessible via member functions (at least at the level we need) so we can't piggyback on that.  

My solution here is to add a `JuliaGcsClient` wrapper that manages the IO service and the associated thread (based on the GCS client test harness code).  ~~As you can see from my `Disconnect` function, I'm struggling to figure out how to tear this all down when it hasn't been connected yet (it segfaults even checking whether the ptr for the IO service is null or not).~~  EDIT: sorted.

Another possible direction would be to use the `PythonGcsClient` which AFAICT would work just fine for our purposes but is marked for "only Python/Cython use", whatever that means.

But the basic get/put functionality works just fine, and I think this is probably okay for now for the purposes of setting up the function manager stuff.