### PR TITLE
First pass on using a Julia function as a Ray task

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 

--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"
 
 [compat]
+ArgParse = "1"
 CxxWrap = "0.13.4"
 JLLWrappers = "1.2.0"
 Mustache = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,12 @@ uuid = "c348cde4-7f22-4730-83d8-6959fb7a17ba"
 version = "0.1.0"
 
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 JLLWrappers = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Mustache = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 libcxxwrap_julia_jll = "3eaa8342-bff7-56a5-9981-c04077f7cee7"

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -26,9 +26,13 @@ void shutdown_coreworker() {
     CoreWorkerProcess::Shutdown();
 }
 
+// https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
+// https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(int node_manager_port) {
+void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
     // RAY_LOG_ENABLED(DEBUG);
+
+    std::cout << "Started" << std::endl;
 
     CoreWorkerOptions options;
     options.worker_type = WorkerType::WORKER;
@@ -45,7 +49,7 @@ void initialize_coreworker_worker(int node_manager_port) {
     options.metrics_agent_port = -1;
     options.startup_token = 0;
     options.task_execution_callback =
-        [](
+        [f](
             const rpc::Address &caller_address,
             TaskType task_type,
             const std::string task_name,
@@ -64,7 +68,9 @@ void initialize_coreworker_worker(int node_manager_port) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-          std::string str = "returned";
+          int pid = f();
+          std::cout << "pid: " << pid << std::endl;
+          std::string str = std::to_string(pid);
           auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
           RAY_CHECK(returns->size() == 1);
           (*returns)[0].second = std::make_shared<RayObject>(memory_buffer, nullptr, std::vector<rpc::ObjectReference>());
@@ -244,7 +250,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // attempting to use the shared library in Julia.
 
     mod.method("initialize_coreworker", &initialize_coreworker);
-    mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
+    mod.method("initialize_coreworker_worker", [] (int node_manager, jlcxx::SafeCFunction julia_func) {
+        auto f = jlcxx::make_function_pointer<int()>(julia_func);
+        return initialize_coreworker_worker(node_manager, f);
+    });
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -7,7 +7,7 @@ void initialize_coreworker(int node_manager_port) {
 
     CoreWorkerOptions options;
     options.worker_type = WorkerType::DRIVER;
-    options.language = Language::PYTHON;
+    options.language = Language::JULIA;
     options.store_socket = "/tmp/ray/session_latest/sockets/plasma_store"; // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = "/tmp/ray/session_latest/sockets/raylet";  // Required by `RayletClient`
     options.job_id = JobID::FromInt(1001);

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -35,7 +35,7 @@ void initialize_coreworker_worker(int node_manager_port) {
     options.language = Language::JULIA;
     options.store_socket = "/tmp/ray/session_latest/sockets/plasma_store"; // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = "/tmp/ray/session_latest/sockets/raylet";  // Required by `RayletClient`
-    options.job_id = JobID::FromInt(-1);
+    // options.job_id = JobID::FromInt(-1);  // For workers, the job ID is assigned by Raylet via an environment variable.
     options.gcs_options = gcs::GcsClientOptions(NODE_MANAGER_IP_ADDRESS + ":6379");
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
@@ -64,6 +64,10 @@ void initialize_coreworker_worker(int node_manager_port) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
+          std::string str = "returned";
+          auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
+          RAY_CHECK(returns->size() == 1);
+          (*returns)[0].second = std::make_shared<RayObject>(memory_buffer, nullptr, std::vector<rpc::ObjectReference>());
           return Status::OK();
         };
     CoreWorkerProcess::Initialize(options);

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -29,7 +29,7 @@ void shutdown_coreworker() {
 // https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(int node_manager_port) {
+void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
     // RAY_LOG_ENABLED(DEBUG);
 
     CoreWorkerOptions options;
@@ -47,7 +47,7 @@ void initialize_coreworker_worker(int node_manager_port) {
     options.metrics_agent_port = -1;
     options.startup_token = 0;
     options.task_execution_callback =
-        [](
+        [f](
             const rpc::Address &caller_address,
             TaskType task_type,
             const std::string task_name,
@@ -66,8 +66,7 @@ void initialize_coreworker_worker(int node_manager_port) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-          jlcxx::JuliaFunction task_executor("task_executor");
-          int pid = task_executor();
+          int pid = f();
           std::string str = std::to_string(pid);
           auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
           RAY_CHECK(returns->size() == 1);
@@ -248,7 +247,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // attempting to use the shared library in Julia.
 
     mod.method("initialize_coreworker", &initialize_coreworker);
-    mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
+    mod.method("initialize_coreworker_worker", [] (int node_manager, jlcxx::SafeCFunction julia_func) {
+        auto f = jlcxx::make_function_pointer<int()>(julia_func);
+        return initialize_coreworker_worker(node_manager, f);
+    });
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -29,10 +29,8 @@ void shutdown_coreworker() {
 // https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
+void initialize_coreworker_worker(int node_manager_port) {
     // RAY_LOG_ENABLED(DEBUG);
-
-    std::cout << "Started" << std::endl;
 
     CoreWorkerOptions options;
     options.worker_type = WorkerType::WORKER;
@@ -49,7 +47,7 @@ void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
     options.metrics_agent_port = -1;
     options.startup_token = 0;
     options.task_execution_callback =
-        [f](
+        [](
             const rpc::Address &caller_address,
             TaskType task_type,
             const std::string task_name,
@@ -68,8 +66,7 @@ void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-          int pid = f();
-          std::cout << "pid: " << pid << std::endl;
+          int pid = 42;
           std::string str = std::to_string(pid);
           auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
           RAY_CHECK(returns->size() == 1);
@@ -252,7 +249,8 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     mod.method("initialize_coreworker", &initialize_coreworker);
     mod.method("initialize_coreworker_worker", [] (int node_manager, jlcxx::SafeCFunction julia_func) {
         auto f = jlcxx::make_function_pointer<int()>(julia_func);
-        return initialize_coreworker_worker(node_manager, f);
+        std::cout << "f: " << f() << std::endl;
+        return initialize_coreworker_worker(node_manager);
     });
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -191,6 +191,7 @@ ObjectID _submit_task(std::string project_dir) {
         FunctionDescriptorBuilder::BuildJulia("", "demo_task", "")
     );
 
+    // TODO: These args are currently being ignored
     std::vector<std::unique_ptr<TaskArg>> args;
     std::string str = "hello";
     auto buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -66,7 +66,8 @@ void initialize_coreworker_worker(int node_manager_port) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-          int pid = 42;
+          jlcxx::JuliaFunction task_executor("task_executor");
+          int pid = task_executor();
           std::string str = std::to_string(pid);
           auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
           RAY_CHECK(returns->size() == 1);
@@ -247,11 +248,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // attempting to use the shared library in Julia.
 
     mod.method("initialize_coreworker", &initialize_coreworker);
-    mod.method("initialize_coreworker_worker", [] (int node_manager, jlcxx::SafeCFunction julia_func) {
-        auto f = jlcxx::make_function_pointer<int()>(julia_func);
-        std::cout << "f: " << f() << std::endl;
-        return initialize_coreworker_worker(node_manager);
-    });
+    mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");
 

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -29,7 +29,7 @@ void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
-ObjectID submit_task();
+ObjectID _submit_task(std::string project_dir);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.
 // we may want to use the PythonGcsClient however, which does not do async

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -18,7 +18,7 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 void initialize_coreworker(int node_manager_port);
-void initialize_coreworker_worker(int node_manager_port);
+void initialize_coreworker_worker(int node_manager_port, int (*f)());
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -16,12 +16,19 @@ using ray::core::CoreWorkerOptions;
 using ray::core::WorkerType;
 using ray::core::RayFunction;
 
+using namespace ray;
+using ray::core::CoreWorkerProcess;
+using ray::core::CoreWorkerOptions;
+using ray::core::RayFunction;
+using ray::core::TaskOptions;
+using ray::core::WorkerType;
+
 void initialize_coreworker(int node_manager_port);
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);
-
 std::string ToString(ray::FunctionDescriptor function_descriptor);
+ObjectID submit_task();
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.
 // we may want to use the PythonGcsClient however, which does not do async

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -14,6 +14,7 @@ using namespace ray;
 using ray::core::CoreWorkerProcess;
 using ray::core::CoreWorkerOptions;
 using ray::core::WorkerType;
+using ray::core::RayFunction;
 
 void initialize_coreworker(int node_manager_port);
 void shutdown_coreworker();

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -24,6 +24,7 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 void initialize_coreworker(int node_manager_port);
+void initialize_coreworker_worker(int node_manager_port);
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -13,12 +13,6 @@
 using namespace ray;
 using ray::core::CoreWorkerProcess;
 using ray::core::CoreWorkerOptions;
-using ray::core::WorkerType;
-using ray::core::RayFunction;
-
-using namespace ray;
-using ray::core::CoreWorkerProcess;
-using ray::core::CoreWorkerOptions;
 using ray::core::RayFunction;
 using ray::core::TaskOptions;
 using ray::core::WorkerType;

--- a/src/ray_core_worker_julia_jll.jl
+++ b/src/ray_core_worker_julia_jll.jl
@@ -5,6 +5,7 @@ using Base
 using Base: UUID
 import JLLWrappers
 using Logging
+using Pkg
 
 JLLWrappers.@generate_main_file_header("ray_core_worker_julia")
 JLLWrappers.@generate_main_file("ray_core_worker_julia", UUID("c348cde4-7f22-4730-83d8-6959fb7a17ba"))

--- a/src/ray_core_worker_julia_jll.jl
+++ b/src/ray_core_worker_julia_jll.jl
@@ -1,8 +1,10 @@
 # Use baremodule to shave off a few KB from the serialized `.ji` file
 baremodule ray_core_worker_julia_jll
+using ArgParse
 using Base
 using Base: UUID
 import JLLWrappers
+using Logging
 
 JLLWrappers.@generate_main_file_header("ray_core_worker_julia")
 JLLWrappers.@generate_main_file("ray_core_worker_julia", UUID("c348cde4-7f22-4730-83d8-6959fb7a17ba"))

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -117,6 +117,11 @@ function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
     return put(CxxWrap.CxxWrapCore.__cxxwrap_smartptr_cast_to_base(buffer))
 end
 
+function demo_task()
+    @info "demo_task called"
+    return getpid()
+end
+
 #=
 julia -e sleep(120) -- \
   /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/venv/lib/python3.10/site-packages/ray/cpp/default_worker \
@@ -160,6 +165,9 @@ function start_worker(args=ARGS)
     open(joinpath(parsed_args["logs_dir"], "julia_worker.log"), "w+") do io
         global_logger(SimpleLogger(io))
         @info "Testing"
-        initialize_coreworker_worker(parsed_args["node_manager_port"])
+        initialize_coreworker_worker(
+            parsed_args["node_manager_port"],
+            CxxWrap.@safe_cfunction(demo_task, Int32, ()),
+        )
     end
 end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -165,6 +165,9 @@ function start_worker(args=ARGS)
     open(joinpath(parsed_args["logs_dir"], "julia_worker.log"), "w+") do io
         global_logger(SimpleLogger(io))
         @info "Testing"
-        initialize_coreworker_worker(parsed_args["node_manager_port"])
+        initialize_coreworker_worker(
+            parsed_args["node_manager_port"],
+            CxxWrap.@safe_cfunction(task_executor, Int32, ()),
+        )
     end
 end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -117,8 +117,8 @@ function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
     return put(CxxWrap.CxxWrapCore.__cxxwrap_smartptr_cast_to_base(buffer))
 end
 
-function demo_task()
-    @info "demo_task called"
+function task_executor()
+    @info "task_executor called"
     return getpid()
 end
 
@@ -165,9 +165,6 @@ function start_worker(args=ARGS)
     open(joinpath(parsed_args["logs_dir"], "julia_worker.log"), "w+") do io
         global_logger(SimpleLogger(io))
         @info "Testing"
-        initialize_coreworker_worker(
-            parsed_args["node_manager_port"],
-            CxxWrap.@safe_cfunction(demo_task, Int32, ()),
-        )
+        initialize_coreworker_worker(parsed_args["node_manager_port"])
     end
 end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -1,5 +1,5 @@
 # export ray_core_worker_julia
-export Language, WorkerType
+export Language, WorkerType, start_worker
 
 using CxxWrap
 using libcxxwrap_julia_jll

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -135,6 +135,11 @@ julia -e sleep(120) -- \
 =#
 function start_worker(args=ARGS)
     s = ArgParseSettings()
+
+    # Worker options are generated in the Raylet function `BuildProcessCommandArgs`
+    # (https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/raylet/worker_pool.cc#L232)
+    # and are parsed in Python here:
+    # https://github.com/ray-project/ray/blob/ray-2.5.1/python/ray/_private/workers/default_worker.py
     @add_arg_table! s begin
         "--ray_raylet_socket_name"
             dest_name = "raylet_socket"
@@ -150,12 +155,24 @@ function start_worker(args=ARGS)
             arg_type = Int
         "--ray_node_ip_address"
             dest_name = "node_ip_address"
+            required=true
+            arg_type=String
+            help="The ip address of the worker's node"
         "--ray_redis_password"
             dest_name = "redis_password"
+            required=false
+            arg_type=String
+            help="the password to use for Redis"
         "--ray_session_dir"
             dest_name = "session_dir"
         "--ray_logs_dir"
             dest_name = "logs_dir"
+        "--runtime-env-hash"
+            dest_name="runtime_env_hash"
+            required=false
+            arg_type=Int
+            default=0
+            help="The computed hash of the runtime env for this worker"
         "arg1"
             required = true
     end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -117,6 +117,14 @@ function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
     return put(CxxWrap.CxxWrapCore.__cxxwrap_smartptr_cast_to_base(buffer))
 end
 
+function Base.take!(buffer::CxxWrap.CxxWrapCore.SmartPointer{<:Buffer})
+    buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
+    buffer_size = Size(buffer[])
+    vec = Vector{UInt8}(undef, buffer_size)
+    unsafe_copyto!(Ptr{UInt8}(pointer(vec)), buffer_ptr, buffer_size)
+    return vec
+end
+
 function task_executor()
     @info "task_executor called"
     return getpid()

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -35,7 +35,6 @@ function node_manager_port()
 end
 
 initialize_coreworker() = initialize_coreworker(node_manager_port())
-initialize_coreworker_worker() = initialize_coreworker_worker(node_manager_port())
 
 # function Base.Symbol(language::Language)
 #     return if language === PYTHON

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -35,6 +35,7 @@ function node_manager_port()
 end
 
 initialize_coreworker() = initialize_coreworker(node_manager_port())
+initialize_coreworker_worker() = initialize_coreworker_worker(node_manager_port())
 
 # function Base.Symbol(language::Language)
 #     return if language === PYTHON

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -116,3 +116,50 @@ Base.show(io::IO, status::Status) = print(io, ToString(status))
 function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
     return put(CxxWrap.CxxWrapCore.__cxxwrap_smartptr_cast_to_base(buffer))
 end
+
+#=
+julia -e sleep(120) -- \
+  /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/venv/lib/python3.10/site-packages/ray/cpp/default_worker \
+  --ray_plasma_store_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/plasma_store \
+  --ray_raylet_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/raylet \
+  --ray_node_manager_port=57236 --ray_address=127.0.0.1:6379 \
+  --ray_redis_password= \
+  --ray_session_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400 \
+  --ray_logs_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/logs \
+  --ray_node_ip_address=127.0.0.1
+=#
+function start_worker(args=ARGS)
+    s = ArgParseSettings()
+    @add_arg_table! s begin
+        "--ray_raylet_socket_name"
+            dest_name = "raylet_socket"
+            arg_type = String
+        "--ray_plasma_store_socket_name"
+            dest_name = "store_socket"
+            arg_type = String
+        "--ray_address"  # "127.0.0.1:6379"
+            dest_name = "address"
+            arg_type = String
+        "--ray_node_manager_port"
+            dest_name = "node_manager_port"
+            arg_type = Int
+        "--ray_node_ip_address"
+            dest_name = "node_ip_address"
+        "--ray_redis_password"
+            dest_name = "redis_password"
+        "--ray_session_dir"
+            dest_name = "session_dir"
+        "--ray_logs_dir"
+            dest_name = "logs_dir"
+        "arg1"
+            required = true
+    end
+
+    parsed_args = parse_args(args, s)
+
+    open(joinpath(parsed_args["logs_dir"], "julia_worker.log"), "w+") do io
+        global_logger(SimpleLogger(io))
+        @info "Testing"
+        initialize_coreworker_worker(parsed_args["node_manager_port"])
+    end
+end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -122,6 +122,10 @@ function task_executor()
     return getpid()
 end
 
+project_dir() = dirname(Pkg.project().path)
+submit_task() = _submit_task(project_dir())
+
+
 #=
 julia -e sleep(120) -- \
   /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/venv/lib/python3.10/site-packages/ray/cpp/default_worker \

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using CxxWrap
 using Test
-using ray_core_worker_julia_jll: initialize_coreworker, shutdown_coreworker, put, get,
-      function_descriptor, FunctionDescriptor
+using ray_core_worker_julia_jll: FunctionDescriptor, function_descriptor
+using ray_core_worker_julia_jll: initialize_coreworker, shutdown_coreworker
+using ray_core_worker_julia_jll: get, put, submit_task
 
 include("utils.jl")
 
@@ -14,6 +15,7 @@ include("utils.jl")
         setup_core_worker() do
             include("put_get.jl")
             include("function_descriptor.jl")
+            include("task.jl")
         end
     end
 end

--- a/test/task.jl
+++ b/test/task.jl
@@ -2,4 +2,5 @@
     oid = submit_task()
     pid = String(take!(get(oid)))
     @test all(isdigit, pid)
+    @test parse(Int, pid) != getpid()
 end

--- a/test/task.jl
+++ b/test/task.jl
@@ -1,0 +1,5 @@
+@testset "Submit task" begin
+    oid = submit_task()
+    pid = String(take!(get(oid)))
+    @test all(isdigit, pid)
+end


### PR DESCRIPTION
Implements the Julia Ray worker. The order of how things are called is as follows:

1. User runs `ray start --head`
2. The C++ raylet initiates a Julia worker prestart (https://github.com/beacon-biosignals/ray/pull/4) which spawns a Python process running `setup_worker.py`
3. The `setup_worker.py` constructs a command to run under `bash`. This calls `julia -e 'using ray_core_worker_julia_jll; ray_core_worker_julia_jll.start_worker()`
4. The `start_worker` parses the flags passed in and runs the Julia core worker C++ code `initialize_coreworker_worker`
5. Now spawn another Julia process to run as the driver and run the following
    ```julia
    using ray_core_worker_julia_jll: initialize_coreworker, shutdown_coreworker, submit_task, get
    initialize_coreworker()
    oid = submit_task()
    @show get(oid)
    shutdown_coreworker()
    ```
6. The Julia Ray task is submitted to the raylet which then dispatches the task to the Julia worker which was prestarted. The Julia worker ignores the task specification and ends up returning `"returned"` as a Ray object.
