### PR TITLE
Execute a predefined named Julia function as a Ray task

### DIFF
--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -30,13 +30,10 @@ void shutdown_coreworker() {
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
 void initialize_coreworker_worker(int node_manager_port, jlcxx::SafeCFunction julia_task_executor) {
-    // void (*task_executor)(
-    //     const RayFunction &ray_function,
-    //     const std::vector<std::shared_ptr<RayObject>> &args,
-    //     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *returns)) {
-
     auto task_executor = jlcxx::make_function_pointer<int(
-         RayFunction
+        RayFunction
+        // const std::vector<std::shared_ptr<RayObject>> &args,
+        // std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *returns
     )>(julia_task_executor);
 
     CoreWorkerOptions options;

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -191,12 +191,12 @@ bool JuliaGcsClient::Exists(const std::string &ns,
     return exists;
 }
 
-ObjectID _submit_task(std::string project_dir) {
+ObjectID _submit_task(std::string project_dir, std::string module_name, std::string function_name) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
     RayFunction func(
         Language::JULIA,
-        FunctionDescriptorBuilder::BuildJulia("", "demo_task", "")
+        FunctionDescriptorBuilder::BuildJulia(module_name, function_name, "")
     );
 
     // TODO: These args are currently being ignored

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -29,8 +29,13 @@ void shutdown_coreworker() {
 // https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
-    // RAY_LOG_ENABLED(DEBUG);
+void initialize_coreworker_worker(int node_manager_port, jlcxx::SafeCFunction julia_task_executor) {
+    // void (*task_executor)(
+    //     const RayFunction &ray_function,
+    //     const std::vector<std::shared_ptr<RayObject>> &args,
+    //     std::vector<std::pair<ObjectID, std::shared_ptr<RayObject>>> *returns)) {
+
+    auto task_executor = jlcxx::make_function_pointer<int()>(julia_task_executor);
 
     CoreWorkerOptions options;
     options.worker_type = WorkerType::WORKER;
@@ -47,7 +52,7 @@ void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
     options.metrics_agent_port = -1;
     options.startup_token = 0;
     options.task_execution_callback =
-        [f](
+        [task_executor](
             const rpc::Address &caller_address,
             TaskType task_type,
             const std::string task_name,
@@ -66,7 +71,8 @@ void initialize_coreworker_worker(int node_manager_port, int (*f)()) {
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-          int pid = f();
+          // task_executor(ray_function, returns, args);
+          int pid = task_executor();
           std::string str = std::to_string(pid);
           auto memory_buffer = std::make_shared<LocalMemoryBuffer>(reinterpret_cast<uint8_t *>(&str[0]), str.size(), true);
           RAY_CHECK(returns->size() == 1);
@@ -253,10 +259,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // attempting to use the shared library in Julia.
 
     mod.method("initialize_coreworker", &initialize_coreworker);
-    mod.method("initialize_coreworker_worker", [] (int node_manager, jlcxx::SafeCFunction julia_func) {
-        auto f = jlcxx::make_function_pointer<int()>(julia_func);
-        return initialize_coreworker_worker(node_manager, f);
-    });
+    mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");
 

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -22,7 +22,7 @@ void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
-ObjectID _submit_task(std::string project_dir, std::string module_name, std::string function_name);
+ObjectID _submit_task(std::string project_dir, const ray::FunctionDescriptor &func_descriptor);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.
 // we may want to use the PythonGcsClient however, which does not do async

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -18,7 +18,6 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 void initialize_coreworker(int node_manager_port);
-void initialize_coreworker_worker(int node_manager_port, int (*f)());
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -22,7 +22,7 @@ void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
-ObjectID _submit_task(std::string project_dir);
+ObjectID _submit_task(std::string project_dir, std::string module_name, std::string function_name);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.
 // we may want to use the PythonGcsClient however, which does not do async

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -127,14 +127,9 @@ end
 function task_executor(ray_function)
     @info "task_executor called"
     fd = GetFunctionDescriptor(ray_function)
-    @info "fd: $fd"
-    @info "Parsing $(CallString(fd))"
-    parsed = Meta.parse(CallString(fd))
-    @info "Evaling $(parsed)"
-    return getpid()
-    # func = eval(parsed)
-    # @info "Function $func"
-    # return func()
+    func = eval(@__MODULE__, Meta.parse(CallString(fd)))
+    @info "Calling $func"
+    return func()
 end
 
 project_dir() = dirname(Pkg.project().path)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -126,16 +126,22 @@ end
 
 function task_executor(ray_function)
     @info "task_executor called"
-    @info "fd: $(GetFunctionDescriptor(ray_function))"
+    fd = GetFunctionDescriptor(ray_function)
+    @info "fd: $fd"
+    @info "Parsing $(CallString(fd))"
+    parsed = Meta.parse(CallString(fd))
+    @info "Evaling $(parsed)"
     return getpid()
+    # func = eval(parsed)
+    # @info "Function $func"
+    # return func()
 end
 
 project_dir() = dirname(Pkg.project().path)
 
 function submit_task(f::Function)
-    module_name = string(parentmodule(f))
-    function_name = string(nameof(f))
-    return _submit_task(project_dir(), module_name, function_name)
+    fd = function_descriptor(f)
+    return _submit_task(project_dir(), fd)
 end
 
 #=

--- a/test/task.jl
+++ b/test/task.jl
@@ -1,5 +1,5 @@
 @testset "Submit task" begin
-    oid = submit_task()
+    oid = submit_task(getpid)
     pid = String(take!(get(oid)))
     @test all(isdigit, pid)
     @test parse(Int, pid) != getpid()


### PR DESCRIPTION
Allows for executing arbitrary Julia functions with these restrictions:

- The function must accessible when loading a fresh Julia session with no imports
- Function must take no arguments
- Function must return an `Int32`

The primary progress here is that the specified function is stored in a function descriptor which is passed to the `task_executor` function in Julia.