### PR TITLE
Parse CoreWorker options from Ray cli passthrough arguments

### DIFF
--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -3,9 +3,9 @@
 void initialize_coreworker(
     std::string raylet_socket,
     std::string store_socket,
-    std::string address,
-    int node_manager_port,
-    std::string node_ip_address) {
+    std::string gcs_address,
+    std::string node_ip_address,
+    int node_manager_port) {
     // RAY_LOG_ENABLED(DEBUG);
 
     CoreWorkerOptions options;
@@ -14,7 +14,7 @@ void initialize_coreworker(
     options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = raylet_socket;  // Required by `RayletClient`
     options.job_id = JobID::FromInt(1001);
-    options.gcs_options = gcs::GcsClientOptions(address);
+    options.gcs_options = gcs::GcsClientOptions(gcs_address);
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
     options.node_ip_address = node_ip_address;
@@ -35,9 +35,9 @@ void shutdown_coreworker() {
 void initialize_coreworker_worker(
     std::string raylet_socket,
     std::string store_socket,
-    std::string address,
+    std::string gcs_address,
+    std::string node_ip_address,
     int node_manager_port,
-    std::string node_ip_address, 
     jlcxx::SafeCFunction julia_task_executor) {
     auto task_executor = jlcxx::make_function_pointer<int(
         RayFunction
@@ -50,7 +50,7 @@ void initialize_coreworker_worker(
     options.language = Language::JULIA;
     options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = raylet_socket;  // Required by `RayletClient`
-    options.gcs_options = gcs::GcsClientOptions(address);
+    options.gcs_options = gcs::GcsClientOptions(gcs_address);
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
     options.node_ip_address = node_ip_address;

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -1,22 +1,25 @@
 #include "wrapper.h"
 
-const std::string NODE_MANAGER_IP_ADDRESS = "127.0.0.1";
-
-void initialize_coreworker(int node_manager_port) {
+void initialize_coreworker(
+    std::string raylet_socket,
+    std::string store_socket,
+    std::string address,
+    int node_manager_port,
+    std::string node_ip_address) {
     // RAY_LOG_ENABLED(DEBUG);
 
     CoreWorkerOptions options;
     options.worker_type = WorkerType::DRIVER;
     options.language = Language::JULIA;
-    options.store_socket = "/tmp/ray/session_latest/sockets/plasma_store"; // Required around `CoreWorkerClientPool` creation
-    options.raylet_socket = "/tmp/ray/session_latest/sockets/raylet";  // Required by `RayletClient`
+    options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
+    options.raylet_socket = raylet_socket;  // Required by `RayletClient`
     options.job_id = JobID::FromInt(1001);
-    options.gcs_options = gcs::GcsClientOptions(NODE_MANAGER_IP_ADDRESS + ":6379");
+    options.gcs_options = gcs::GcsClientOptions(address);
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
-    options.node_ip_address = NODE_MANAGER_IP_ADDRESS;
+    options.node_ip_address = node_ip_address;
     options.node_manager_port = node_manager_port;
-    options.raylet_ip_address = NODE_MANAGER_IP_ADDRESS;
+    options.raylet_ip_address = node_ip_address;
     options.metrics_agent_port = -1;
     options.driver_name = "julia_core_worker_test";
     CoreWorkerProcess::Initialize(options);
@@ -29,7 +32,13 @@ void shutdown_coreworker() {
 // https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(int node_manager_port, jlcxx::SafeCFunction julia_task_executor) {
+void initialize_coreworker_worker(
+    std::string raylet_socket,
+    std::string store_socket,
+    std::string address,
+    int node_manager_port,
+    std::string node_ip_address, 
+    jlcxx::SafeCFunction julia_task_executor) {
     auto task_executor = jlcxx::make_function_pointer<int(
         RayFunction
         // const std::vector<std::shared_ptr<RayObject>> &args,
@@ -39,15 +48,14 @@ void initialize_coreworker_worker(int node_manager_port, jlcxx::SafeCFunction ju
     CoreWorkerOptions options;
     options.worker_type = WorkerType::WORKER;
     options.language = Language::JULIA;
-    options.store_socket = "/tmp/ray/session_latest/sockets/plasma_store"; // Required around `CoreWorkerClientPool` creation
-    options.raylet_socket = "/tmp/ray/session_latest/sockets/raylet";  // Required by `RayletClient`
-    // options.job_id = JobID::FromInt(-1);  // For workers, the job ID is assigned by Raylet via an environment variable.
-    options.gcs_options = gcs::GcsClientOptions(NODE_MANAGER_IP_ADDRESS + ":6379");
+    options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
+    options.raylet_socket = raylet_socket;  // Required by `RayletClient`
+    options.gcs_options = gcs::GcsClientOptions(address);
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
-    options.node_ip_address = NODE_MANAGER_IP_ADDRESS;
+    options.node_ip_address = node_ip_address;
     options.node_manager_port = node_manager_port;
-    options.raylet_ip_address = NODE_MANAGER_IP_ADDRESS;
+    options.raylet_ip_address = node_ip_address;
     options.metrics_agent_port = -1;
     options.startup_token = 0;
     options.task_execution_callback =
@@ -353,4 +361,3 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("Keys", &JuliaGcsClient::Keys)
         .method("Exists", &JuliaGcsClient::Exists);
 }
-

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -25,14 +25,6 @@ void initialize_coreworker(
     std::string node_ip_address,
     int node_manager_port);
 
-void initialize_coreworker_worker(
-    std::string raylet_socket,
-    std::string store_socket,
-    std::string gcs_address,
-    std::string node_ip_address,
-    int node_manager_port,
-    int (*f)());
-
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -22,15 +22,15 @@ void initialize_coreworker(
     std::string raylet_socket,
     std::string store_socket,
     std::string gcs_address,
-    int node_manager_port,
-    std::string node_ip_address);
+    std::string node_ip_address,
+    int node_manager_port);
 
 void initialize_coreworker_worker(
     std::string raylet_socket,
     std::string store_socket,
-    std::string address,
-    int node_manager_port,
+    std::string gcs_address,
     std::string node_ip_address,
+    int node_manager_port,
     int (*f)());
 
 void shutdown_coreworker();

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -17,7 +17,22 @@ using ray::core::RayFunction;
 using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
-void initialize_coreworker(int node_manager_port);
+
+void initialize_coreworker(
+    std::string raylet_socket,
+    std::string store_socket,
+    std::string gcs_address,
+    int node_manager_port,
+    std::string node_ip_address);
+
+void initialize_coreworker_worker(
+    std::string raylet_socket,
+    std::string store_socket,
+    std::string address,
+    int node_manager_port,
+    std::string node_ip_address,
+    int (*f)());
+
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -64,19 +64,14 @@ function parse_ray_args()
     port_match = match(r"node-manager-port=([0-9]{1,5})", line)
     node_port = port_match !== nothing ? parse(Int, port_match[1]) : error("Unable to find Node Manager port")
 
-    return (raylet, store, node_ip, node_port, gcs_address)
-end
-
-
-function initialize_coreworker()
-
-    raylet, store, node_ip, node_port, gcs_address = parse_ray_args()
-
     # TODO: downgrade to debug
     @info "Raylet socket: $raylet, Object store: $store, Node IP: $node_ip, Node port: $node_port, GCS Address: $gcs_address"
 
-    return initialize_coreworker(raylet, store, gcs_address, node_ip, node_port)
+    return (raylet, store, gcs_address, node_ip, node_port)
 end
+
+
+initialize_coreworker() = initialize_coreworker(parse_ray_args()...)
 
 # function Base.Symbol(language::Language)
 #     return if language === PYTHON

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -43,13 +43,13 @@ function parse_ray_args()
         end
     end
 
-    gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{4})", line)
+    gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5})", line)
     gcs_address = gcs_match !== nothing ? String(gcs_match[1]) : error("Unable to find GCS address")
 
     node_ip_match = match(r"node-ip-address=(([0-9]{1,3}\.){3}[0-9]{1,3})", line)
     node_ip = node_ip_match !== nothing ? String(node_ip_match[1]) : error("Unable to find Node IP address")
 
-    port_match = match(r"node-manager-port=([0-9]+)", line)
+    port_match = match(r"node-manager-port=([0-9]{1,5})", line)
     node_port = port_match !== nothing ? parse(Int, port_match[1]) : error("Unable to find Node Manager port")
 
     return (node_ip, node_port, gcs_address)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -144,7 +144,8 @@ julia -e sleep(120) -- \
   /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/venv/lib/python3.10/site-packages/ray/cpp/default_worker \
   --ray_plasma_store_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/plasma_store \
   --ray_raylet_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/raylet \
-  --ray_node_manager_port=57236 --ray_address=127.0.0.1:6379 \
+  --ray_node_manager_port=57236
+  --ray_address=127.0.0.1:6379 \
   --ray_redis_password= \
   --ray_session_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400 \
   --ray_logs_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/logs \
@@ -179,6 +180,7 @@ function start_worker(args=ARGS)
             dest_name = "redis_password"
             required=false
             arg_type=String
+            default=""
             help="the password to use for Redis"
         "--ray_session_dir"
             dest_name = "session_dir"
@@ -203,6 +205,13 @@ function start_worker(args=ARGS)
     @info "Testing"
     initialize_coreworker_worker(
         parsed_args["node_manager_port"],
+        parsed_args["raylet_socket"],
+        parsed_args["store_socket"],
+        parsed_args["address"],
+        parsed_args["node_manager_port"],
+        parsed_args["node_ip_address"],
+        parsed_args["logs_dir"],
+        parsed_args["runtime_env_hash"],
         CxxWrap.@safe_cfunction(
             task_executor,
             Int32,

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -178,7 +178,7 @@ julia -e sleep(120) -- \
   /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/venv/lib/python3.10/site-packages/ray/cpp/default_worker \
   --ray_plasma_store_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/plasma_store \
   --ray_raylet_socket_name=/tmp/ray/session_2023-08-09_14-14-28_230005_27400/sockets/raylet \
-  --ray_node_manager_port=57236
+  --ray_node_manager_port=57236 \
   --ray_address=127.0.0.1:6379 \
   --ray_redis_password= \
   --ray_session_dir=/tmp/ray/session_2023-08-09_14-14-28_230005_27400 \

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -64,6 +64,7 @@ function initialize_coreworker()
 
     node_ip, node_port, gcs_address = parse_ray_args()
 
+    # TODO: downgrade to debug
     @info "Node IP: $node_ip, Node port: $node_port, GCS Address: $gcs_address"
 
     return initialize_coreworker(raylet_socket, store_socket, gcs_address, node_ip, node_port)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -43,6 +43,12 @@ function parse_ray_args()
         end
     end
 
+    raylet_match = match(r"raylet-name=((\/[a-z,0-9,_,-]+)+)", line)
+    raylet = raylet_match !== nothing ? String(raylet_match[1]) : error("Unable to find Raylet socket")
+
+    store_match = match(r"object-store-name=((\/[a-z,0-9,_,-]+)+)", line)
+    store = raylet_match !== nothing ? String(raylet_match[1]) : error("Unable to find Object store socket")
+
     gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5})", line)
     gcs_address = gcs_match !== nothing ? String(gcs_match[1]) : error("Unable to find GCS address")
 
@@ -52,20 +58,16 @@ function parse_ray_args()
     port_match = match(r"node-manager-port=([0-9]{1,5})", line)
     node_port = port_match !== nothing ? parse(Int, port_match[1]) : error("Unable to find Node Manager port")
 
-    return (node_ip, node_port, gcs_address)
+    return (raylet, store, node_ip, node_port, gcs_address)
 end
 
 
 function initialize_coreworker()
 
-    # TODO: are these defaults? can they be overwritten by user and/or Ray?
-    raylet_socket = "/tmp/ray/session_latest/sockets/raylet"
-    store_socket = "/tmp/ray/session_latest/sockets/plasma_store"
-
-    node_ip, node_port, gcs_address = parse_ray_args()
+    raylet, store, node_ip, node_port, gcs_address = parse_ray_args()
 
     # TODO: downgrade to debug
-    @info "Node IP: $node_ip, Node port: $node_port, GCS Address: $gcs_address"
+    @info "Raylet socket: $raylet, Object store: $store, Node IP: $node_ip, Node port: $node_port, GCS Address: $gcs_address"
 
     return initialize_coreworker(raylet_socket, store_socket, gcs_address, node_ip, node_port)
 end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -50,7 +50,7 @@ function parse_ray_args()
 
     # --object-store-name=/tmp/ray/session_2023-08-14_18-52-23_003681_54068/sockets/plasma_store
     store_match = match(r"object-store-name=((\/[a-z,0-9,_,-]+)+)", line)
-    store = raylet_match !== nothing ? String(raylet_match[1]) : error("Unable to find Object store socket")
+    store = store_match !== nothing ? String(store_match[1]) : error("Unable to find Object Store socket")
 
     # --gcs-address=127.0.0.1:6379
     gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5})", line)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -238,6 +238,7 @@ function start_worker(args=ARGS)
     global_logger(FileLogger(joinpath(parsed_args["logs_dir"], "julia_worker.log");
                              append=true, always_flush=true))
     @info "Testing"
+    @info "$parsed_args"
     initialize_coreworker_worker(
         parsed_args["raylet_socket"],
         parsed_args["store_socket"],

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -43,18 +43,24 @@ function parse_ray_args()
         end
     end
 
+
+    # --raylet-name=/tmp/ray/session_2023-08-14_18-52-23_003681_54068/sockets/raylet
     raylet_match = match(r"raylet-name=((\/[a-z,0-9,_,-]+)+)", line)
     raylet = raylet_match !== nothing ? String(raylet_match[1]) : error("Unable to find Raylet socket")
 
+    # --object-store-name=/tmp/ray/session_2023-08-14_18-52-23_003681_54068/sockets/plasma_store
     store_match = match(r"object-store-name=((\/[a-z,0-9,_,-]+)+)", line)
     store = raylet_match !== nothing ? String(raylet_match[1]) : error("Unable to find Object store socket")
 
+    # --gcs-address=127.0.0.1:6379
     gcs_match = match(r"gcs-address=(([0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]{1,5})", line)
     gcs_address = gcs_match !== nothing ? String(gcs_match[1]) : error("Unable to find GCS address")
 
+    # --node-ip-address=127.0.0.1
     node_ip_match = match(r"node-ip-address=(([0-9]{1,3}\.){3}[0-9]{1,3})", line)
     node_ip = node_ip_match !== nothing ? String(node_ip_match[1]) : error("Unable to find Node IP address")
 
+    # --node-manager-port=63639
     port_match = match(r"node-manager-port=([0-9]{1,5})", line)
     node_port = port_match !== nothing ? parse(Int, port_match[1]) : error("Unable to find Node Manager port")
 
@@ -69,7 +75,7 @@ function initialize_coreworker()
     # TODO: downgrade to debug
     @info "Raylet socket: $raylet, Object store: $store, Node IP: $node_ip, Node port: $node_port, GCS Address: $gcs_address"
 
-    return initialize_coreworker(raylet_socket, store_socket, gcs_address, node_ip, node_port)
+    return initialize_coreworker(raylet, store, gcs_address, node_ip, node_port)
 end
 
 # function Base.Symbol(language::Language)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -20,20 +20,6 @@ function __init__()
     @initcxx
 end  # __init__()
 
-function node_manager_port()
-    line = open("/tmp/ray/session_latest/logs/raylet.out") do io
-        while !eof(io)
-            line = readline(io)
-            if contains(line, "NodeManager server started")
-                return line
-            end
-        end
-    end
-
-    m = match(r"port (\d+)", line)
-    return m !== nothing ? parse(Int, m[1]) : error("Unable to find port")
-end
-
 function parse_ray_args()
    #==
     "Starting agent process with command: ...


### PR DESCRIPTION
Currently we hardcode the `CoreWorkerOptions` values in both `initialize_coreworker` and `initialize_coreworker_worker` functions. 

These changes allow for `initialize_coreworker_worker` to parse these values from the ray CLI `passthrough` args.

For the `initialize_coreworker` function, we continue to parse the `raylet.out` logs for CLI args.

~~The `raylet_socket` and `store_socket` continue to be hardcoded but I'm almost certain these are sensible defaults anyway.~~