### PR TITLE
integrate function manager and task prototypes

### DIFF
--- a/Ray.jl/src/Ray.jl
+++ b/Ray.jl/src/Ray.jl
@@ -16,7 +16,7 @@ using ray_core_worker_julia_jll: shutdown_coreworker
 
 import ray_core_worker_julia_jll as rayjll
 
-export start_worker, initialize_coreworker, shutdown_coreworker, submit_task
+export start_worker, shutdown_coreworker, submit_task
 include("runtime.jl")
 
 include("function_manager.jl")

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -4,14 +4,14 @@
 # "function_id" key and values taht are named tuples of name/function/max_calls.
 #
 # python remote function sets a UUID4 at construction time:
-# https://github.com/beacon-biosignals/ray/blob/beacon-main/python/ray/remote_function.py#L128
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L128
 #
 # ...that's used to set the function_hash (???)...
-# https://github.com/beacon-biosignals/ray/blob/beacon-main/python/ray/remote_function.py#L263-L265
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/remote_function.py#L263-L265
 #
 # later comment suggests that "ideally" they'd use the hash of the pickled
 # function:
-# https://github.com/beacon-biosignals/ray/blob/beacon-main/python/ray/includes/function_descriptor.pxi#L183-L186
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/includes/function_descriptor.pxi#L183-L186
 # 
 # ...but that it's not stable for some reason.  but.....neither is a random
 # UUID?????
@@ -27,7 +27,7 @@
 using ray_core_worker_julia_jll: JuliaGcsClient, Exists, Put, Get,
                                  JuliaFunctionDescriptor, function_descriptor
 
-# python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/dfk%2Fusing-Ray/python/ray/_private/ray_constants.py#L380
+# python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/_private/ray_constants.py#L380
 # so "jlfun" seems reasonable
 const FUNCTION_MANAGER_NAMESPACE = "jlfun"
 

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -96,7 +96,7 @@ function import_function!(fm::FunctionManager, fd::JuliaFunctionDescriptor,
             f = deserialize(iob64)
             # need to handle world-age issues on remote workers when
             # deserializing the function effectively defines it
-            return (args...) -> invokelatest(f, args...)
+            return (args...) -> Base.invokelatest(f, args...)
         catch e
             error("Failed to deserialize function from store: $(fd)")
         end

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -26,8 +26,9 @@
 
 using ray_core_worker_julia_jll: JuliaGcsClient, Exists, Put, Get, JuliaFunctionDescriptor, function_descriptor
 
-# XXX: what's the actual namespace to use?  probably set per-job but I dunno.
-const FUNCTION_MANAGER_NAMESPACE = "JuliaFunctions"
+# python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/dfk%2Fusing-Ray/python/ray/_private/ray_constants.py#L380
+# so "jlfun" seems reasonable
+const FUNCTION_MANAGER_NAMESPACE = "jlfun"
 
 Base.@kwdef struct FunctionManager
     gcs_client::JuliaGcsClient

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -61,7 +61,7 @@ function submit_task(f::Function)
 end
 
 function task_executor(ray_function)
-    @info "task_executor called"
+    @info "task_executor called for JobID $(rayjll.GetCurrentJobId())"
     fd = rayjll.GetFunctionDescriptor(ray_function)
     # for some reason, `eval` gets shadowed by the Core (1-arg only) version
     func = Base.eval(@__MODULE__, Meta.parse(rayjll.CallString(fd)))

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -10,7 +10,8 @@ function init()
     end
 
     args = parse_ray_args_from_raylet_out()
-    initialize_coreworker(args...)
+    # TODO: use global state accessor to get next job id and provide that here
+    initialize_coreworker_driver(args...)
     atexit(rayjll.shutdown_coreworker)
 
     gcs_address = args[3]
@@ -76,8 +77,8 @@ end
 # information instead of parsing logs?  I can't quite tell where it's coming
 # from (set from a `ray.address` config option):
 # https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java#L165-L171
-initialize_coreworker() = initialize_coreworker(parse_ray_args_from_raylet_out()...)
-initialize_coreworker(args...) = rayjll.initialize_coreworker(args...)
+initialize_coreworker_driver() = initialize_coreworker_driver(parse_ray_args_from_raylet_out()...)
+initialize_coreworker_driver(args...) = rayjll.initialize_coreworker_driver(args...)
 
 project_dir() = dirname(Pkg.project().path)
 

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -3,7 +3,7 @@ function init()
     # more like what hte python Worker class does, getting node ID at
     # initialization and using that as a proxy for whether it's connected or not
     #
-    # https://github.com/beacon-biosignals/ray/blob/dfk%2Fusing-Ray/python/ray/_private/worker.py#L421
+    # https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/_private/worker.py#L421
     if isassigned(FUNCTION_MANAGER)
         @warn "Ray already initialized, skipping..."
         return nothing
@@ -75,7 +75,7 @@ end
 # TODO: use something like the java config bootstrap address (?) to get this
 # information instead of parsing logs?  I can't quite tell where it's coming
 # from (set from a `ray.address` config option):
-# https://github.com/beacon-biosignals/ray/blob/beacon-main/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java#L165-L171
+# https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/java/runtime/src/main/java/io/ray/runtime/config/RayConfig.java#L165-L171
 initialize_coreworker() = initialize_coreworker(parse_ray_args_from_raylet_out()...)
 initialize_coreworker(args...) = rayjll.initialize_coreworker(args...)
 

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -164,6 +164,7 @@ function start_worker(args=ARGS)
 
     _init_global_function_manager(parsed_args["address"])
 
+    # TODO: pass "debug mode" as a flag somehow
     ENV["JULIA_DEBUG"] = "Ray"
     logfile = joinpath(parsed_args["logs_dir"], "julia_worker_$(getpid()).log")
     global_logger(FileLogger(logfile; append=true, always_flush=true))

--- a/Ray.jl/test/utils.jl
+++ b/Ray.jl/test/utils.jl
@@ -14,7 +14,7 @@ function setup_ray_head_node(body)
 end
     
 function setup_core_worker(body)
-    initialize_coreworker()
+    Ray.init()
     try
         body()
     finally

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -141,6 +141,11 @@ ray::JuliaFunctionDescriptor function_descriptor(const std::string &mod,
     return *ptr;
 }
 
+ray::JuliaFunctionDescriptor unwrap_function_descriptor(ray::FunctionDescriptor fd) {
+    auto ptr = fd->As<JuliaFunctionDescriptor>();
+    return *ptr;
+}
+
 std::string CallString(ray::FunctionDescriptor function_descriptor)
 {
     return function_descriptor->CallString();
@@ -336,6 +341,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
 
     mod.method("BuildJulia", &FunctionDescriptorBuilder::BuildJulia);
     mod.method("function_descriptor", &function_descriptor);
+    mod.method("unwrap_function_descriptor", &unwrap_function_descriptor);
     mod.method("ToString", &ToString);
     mod.method("CallString", &CallString);
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -13,7 +13,8 @@ void initialize_coreworker_driver(
     options.language = Language::JULIA;
     options.store_socket = store_socket;    // Required around `CoreWorkerClientPool` creation
     options.raylet_socket = raylet_socket;  // Required by `RayletClient`
-    // XXX: this is hard coded! very bad!!!
+    // XXX: this is hard coded! very bad!!! should use global state accessor to
+    // get next job id instead
     options.job_id = JobID::FromInt(1001);
     options.gcs_options = gcs::GcsClientOptions(gcs_address);
     // options.enable_logging = true;

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -1,6 +1,6 @@
 #include "wrapper.h"
 
-void initialize_coreworker(
+void initialize_coreworker_driver(
     std::string raylet_socket,
     std::string store_socket,
     std::string gcs_address,
@@ -292,7 +292,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // the function. If you fail to do this you'll get a "No appropriate factory for type" upon
     // attempting to use the shared library in Julia.
 
-    mod.method("initialize_coreworker", &initialize_coreworker);
+    mod.method("initialize_coreworker_driver", &initialize_coreworker_driver);
     mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -18,7 +18,7 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 
-void initialize_coreworker(
+void initialize_coreworker_driver(
     std::string raylet_socket,
     std::string store_socket,
     std::string gcs_address,

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -123,6 +123,7 @@ function Base.getproperty(fd::JuliaFunctionDescriptor, field::Symbol)
 end
 
 Base.show(io::IO, status::Status) = print(io, ToString(status))
+Base.show(io::IO, jobid::JobID) = print(io, Int(ToInt(jobid)))
 
 #####
 ##### Upstream fixes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using CxxWrap
 using Test
 using ray_core_worker_julia_jll: JuliaFunctionDescriptor, function_descriptor
-using ray_core_worker_julia_jll: initialize_coreworker, shutdown_coreworker
 using ray_core_worker_julia_jll: get, put
 
 include("utils.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -27,11 +27,11 @@ function node_manager_port()
 end
 
 function setup_core_worker(body)
-    initialize_coreworker("/tmp/ray/session_latest/sockets/raylet",
-                          "/tmp/ray/session_latest/sockets/plasma_store",
-                          "127.0.0.1:6379",
-                          "127.0.0.1",
-                          node_manager_port())
+    initialize_coreworker_driver("/tmp/ray/session_latest/sockets/raylet",
+                                 "/tmp/ray/session_latest/sockets/plasma_store",
+                                 "127.0.0.1:6379",
+                                 "127.0.0.1",
+                                 node_manager_port())
     try
         body()
     finally

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,3 +1,5 @@
+using ray_core_worker_julia_jll: initialize_coreworker_driver, shutdown_coreworker
+
 function setup_ray_head_node(body)
     prestarted = success(`ray status`)
     if !prestarted


### PR DESCRIPTION
This is a followup to #20 and #19 which 
- introduces a global function manager in Ray.jl
- slightly improves initialization and jobid handling (now gets jobid from coreworkerprocess)
- exports function on task submit
- imports function in task executor

I'd say it's still WIP; a _single_ task invocation works great!  even with `submit_task(() -> getpid())`.  but for some reaosn things deadlock on any further task submissions, with no errors in the raylet.err or `julia_worker_$(PID).log` files.