### PR TITLE
get jobid from GCS global state accessor

### DIFF
--- a/deps/BUILD.bazel
+++ b/deps/BUILD.bazel
@@ -25,6 +25,7 @@ cc_binary(
     copts = JULIA_CORE_WORKER_COPTS,
     deps = [
         "@com_github_ray_project_ray//:core_worker_lib",
+        "@com_github_ray_project_ray//:global_state_accessor_lib",
         "@julia//:headers",
         "@libcxxwrap_julia//:headers",
     ],

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -386,4 +386,7 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("Get", &JuliaGcsClient::Get)
         .method("Keys", &JuliaGcsClient::Keys)
         .method("Exists", &JuliaGcsClient::Exists);
+
+    mod.add_type<ray::gcs::GlobalStateAccessor>("GlobalStateAccessor")
+        .method("GetNextJobID", &ray::gcs::GlobalStateAccessor::GetNextJobID);
 }

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -5,7 +5,8 @@ void initialize_coreworker_driver(
     std::string store_socket,
     std::string gcs_address,
     std::string node_ip_address,
-    int node_manager_port) {
+    int node_manager_port,
+    JobID job_id) {
     // RAY_LOG_ENABLED(DEBUG);
 
     CoreWorkerOptions options;
@@ -15,7 +16,7 @@ void initialize_coreworker_driver(
     options.raylet_socket = raylet_socket;  // Required by `RayletClient`
     // XXX: this is hard coded! very bad!!! should use global state accessor to
     // get next job id instead
-    options.job_id = JobID::FromInt(1001);
+    options.job_id = job_id;
     options.gcs_options = gcs::GcsClientOptions(gcs_address);
     // options.enable_logging = true;
     // options.install_failure_signal_handler = true;
@@ -293,15 +294,16 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     // the function. If you fail to do this you'll get a "No appropriate factory for type" upon
     // attempting to use the shared library in Julia.
 
+    mod.add_type<JobID>("JobID")
+        .method("ToInt", &JobID::ToInt);
+
+    mod.method("GetCurrentJobId", &GetCurrentJobId);
+
     mod.method("initialize_coreworker_driver", &initialize_coreworker_driver);
     mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
     mod.method("shutdown_coreworker", &shutdown_coreworker);
     mod.add_type<ObjectID>("ObjectID");
 
-    mod.add_type<JobID>("JobID")
-        .method("ToInt", &JobID::ToInt);
-
-    mod.method("GetCurrentJobId", &GetCurrentJobId);
 
     // enum Language
     mod.add_bits<ray::Language>("Language", jlcxx::julia_type("CppEnum"));
@@ -387,6 +389,12 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
         .method("Keys", &JuliaGcsClient::Keys)
         .method("Exists", &JuliaGcsClient::Exists);
 
-    mod.add_type<ray::gcs::GlobalStateAccessor>("GlobalStateAccessor")
-        .method("GetNextJobID", &ray::gcs::GlobalStateAccessor::GetNextJobID);
+    mod.add_type<gcs::GcsClientOptions>("GcsClientOptions")
+        .constructor<const std::string&>();
+
+    mod.add_type<gcs::GlobalStateAccessor>("GlobalStateAccessor")
+        .constructor<const gcs::GcsClientOptions&>()
+        .method("GetNextJobID", &ray::gcs::GlobalStateAccessor::GetNextJobID)
+        .method("Connect", &ray::gcs::GlobalStateAccessor::Connect)
+        .method("Disconnect", &ray::gcs::GlobalStateAccessor::Disconnect);
 }

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -8,6 +8,7 @@
 #include "ray/core_worker/core_worker.h"
 #include "src/ray/protobuf/common.pb.h"
 #include "ray/gcs/gcs_client/gcs_client.h"
+#include "ray/gcs/gcs_client/global_state_accessor.h"
 #include "ray/common/asio/instrumented_io_context.h"
 
 using namespace ray;

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -24,7 +24,8 @@ void initialize_coreworker_driver(
     std::string store_socket,
     std::string gcs_address,
     std::string node_ip_address,
-    int node_manager_port);
+    int node_manager_port,
+    JobID job_id);
 
 void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);


### PR DESCRIPTION
I ended up removing the no-argument `initialize_coreworker_driver` entrypoint since I didn't want to put the job id detection stuff in there (rather than in `init`), but not 100% wedded to that decision.

for now the only method I wrapped from the global state accessor is the one to get the next job id (plus setup/teardown stuff).  I don't _think_ we really need any more than that.  In fact, the vanilla GCS client has a next job ID endpoint as well, but I considered and rejected that in #16 (in favor of hte "python gcs client" which doesn't like kill your session when it fails to connect or require fiddling with threads/asyncio/boost).