### PR TITLE
pass `--startup_token` through to julia workers

### DIFF
--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -215,5 +215,4 @@ function start_worker(args=ARGS)
                                parsed_args["node_manager_port"],
                                parsed_args["startup_token"],
                                task_executor)
-
 end

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -188,6 +188,11 @@ function start_worker(args=ARGS)
             arg_type=Int
             default=0
             help="The computed hash of the runtime env for this worker"
+        "--startup_token"
+            dest_name="startup_token"
+            required=false
+            arg_type=Int
+            default=0
         "arg1"
             required = true
     end
@@ -208,6 +213,7 @@ function start_worker(args=ARGS)
                                parsed_args["address"],
                                parsed_args["node_ip_address"],
                                parsed_args["node_manager_port"],
+                               parsed_args["startup_token"],
                                task_executor)
 
 end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -1,12 +1,13 @@
 @testset "Submit task" begin
-    # oid = submit_task(Int32 ∘ length, ["hello"])
-    # result = String(take!(ray_core_worker_julia_jll.get(oid)))
-    # @test all(isdigit, result)
-    # @test parse(Int, result) == 5
-
+    oid1 = submit_task(Int32 ∘ length, "hello")
     addme(x...) = Int32(sum(x))
-    oid = submit_task(addme, 1, 2, 3)
-    result = String(take!(ray_core_worker_julia_jll.get(oid)))
-    @test all(isdigit, result)
-    @test parse(Int, result) == 6
+    oid2 = submit_task(addme, 1, 2, 3)
+
+    result1 = String(take!(ray_core_worker_julia_jll.get(oid1)))
+    @test all(isdigit, result1)
+    @test parse(Int, result1) == 5
+
+    result2 = String(take!(ray_core_worker_julia_jll.get(oid2)))
+    @test all(isdigit, result2)
+    @test parse(Int, result2) == 6
 end

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -41,6 +41,7 @@ void initialize_coreworker_worker(
     std::string gcs_address,
     std::string node_ip_address,
     int node_manager_port,
+    int64_t startup_token,
     jlcxx::SafeCFunction julia_task_executor) {
     auto task_executor = jlcxx::make_function_pointer<int(
         RayFunction,
@@ -60,7 +61,7 @@ void initialize_coreworker_worker(
     options.node_manager_port = node_manager_port;
     options.raylet_ip_address = node_ip_address;
     options.metrics_agent_port = -1;
-    options.startup_token = 0;
+    options.startup_token = startup_token;
     options.task_execution_callback =
         [task_executor](
             const rpc::Address &caller_address,

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -81,6 +81,7 @@ void initialize_coreworker_worker(
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
+            std::cerr << "entered task_execuation_callback..." << std::endl;
           // task_executor(ray_function, returns, args);
           int pid = task_executor(ray_function, args);
           std::string str = std::to_string(pid);
@@ -89,9 +90,14 @@ void initialize_coreworker_worker(
           (*returns)[0].second = std::make_shared<RayObject>(memory_buffer, nullptr, std::vector<rpc::ObjectReference>());
           return Status::OK();
         };
+    std::cerr << "Initializing julia worker coreworker" << std::endl;
     CoreWorkerProcess::Initialize(options);
 
+    std::cerr << "Starting julia worker task execution loop" << std::endl;
     CoreWorkerProcess::RunTaskExecutionLoop();
+
+    // doesn't seem to be reached...
+    std::cerr << "Julia worker coreworker initialized" << std::endl;
 }
 
 // TODO: probably makes more sense to have a global worker rather than calling

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -82,7 +82,7 @@ void initialize_coreworker_worker(
             const std::string name_of_concurrency_group_to_execute,
             bool is_reattempt,
             bool is_streaming_generator) {
-            std::cerr << "entered task_execuation_callback..." << std::endl;
+            RAY_LOG(DEBUG) << "ray_core_worker_julia_jll: entered task_execuation_callback...";
           // task_executor(ray_function, returns, args);
           int pid = task_executor(ray_function, args);
           std::string str = std::to_string(pid);
@@ -91,14 +91,13 @@ void initialize_coreworker_worker(
           (*returns)[0].second = std::make_shared<RayObject>(memory_buffer, nullptr, std::vector<rpc::ObjectReference>());
           return Status::OK();
         };
-    std::cerr << "Initializing julia worker coreworker" << std::endl;
+    RAY_LOG(DEBUG) << "ray_core_worker_julia_jll: Initializing julia worker coreworker";
     CoreWorkerProcess::Initialize(options);
 
-    std::cerr << "Starting julia worker task execution loop" << std::endl;
+    RAY_LOG(DEBUG) << "ray_core_worker_julia_jll: Starting julia worker task execution loop";
     CoreWorkerProcess::RunTaskExecutionLoop();
 
-    // doesn't seem to be reached...
-    std::cerr << "Julia worker coreworker initialized" << std::endl;
+    RAY_LOG(DEBUG) << "ray_core_worker_julia_jll: Task execution loop exited";
 }
 
 // TODO: probably makes more sense to have a global worker rather than calling

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -12,7 +12,7 @@
 #include "ray/gcs/gcs_client/global_state_accessor.h"
 #include "ray/common/asio/instrumented_io_context.h"
 #include "ray/common/ray_object.h"
-
+#include "ray/util/logging.h"
 
 using namespace ray;
 using ray::core::CoreWorkerProcess;

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -180,4 +180,5 @@ function start_worker(raylet_socket, store_socket, ray_address, node_ip_address,
                                         ray_address, node_ip_address,
                                         node_manager_port, startup_token,
                                         cfunc)
+    @info "worker exiting `ray_core_worker_julia_jll.start_worker`"
 end

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -151,7 +151,7 @@ _submit_task(dir, fd, oids::AbstractVector) = _submit_task(dir, fd, StdVector(oi
 #####
 
 function start_worker(raylet_socket, store_socket, ray_address, node_ip_address,
-                      node_manager_port, task_executor::Function)
+                      node_manager_port, startup_token, task_executor::Function)
     # need to use `@eval` since `task_executor` is only defined at runtime
     cfunc = @eval CxxWrap.@safe_cfunction($(task_executor),
                                           Int32,
@@ -178,5 +178,6 @@ function start_worker(raylet_socket, store_socket, ray_address, node_ip_address,
     @info "cfunction generated!"
     return initialize_coreworker_worker(raylet_socket, store_socket,
                                         ray_address, node_ip_address,
-                                        node_manager_port, cfunc)
+                                        node_manager_port, startup_token,
+                                        cfunc)
 end


### PR DESCRIPTION
Depends on https://github.com/beacon-biosignals/ray/pull/7.  Partially addresses #30 since it allows multiple workers to be created.  But doesn't fix the underlying issue of not re-using existing worker...