### PR TITLE
check for oversize functions before exporting

### DIFF
--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -42,7 +42,7 @@ function check_oversized_function(serialized, function_descriptor)
               "large ($(_mib_string(len))); FUNCTION_SIZE_ERROR_THRESHOLD=" *
               "$(_mib_string(FUNCTION_SIZE_ERROR_THRESHOLD)). " * check_msg
         throw(ArgumentError(msg))
-    elseif length(serialized) > FUNCTION_SIZE_WARN_THRESHOLD
+    elseif len > FUNCTION_SIZE_WARN_THRESHOLD
         msg = "The function $(rayjll.CallString(function_descriptor)) is very " *
               "large ($(_mib_string(len))). " * check_msg
         @warn msg

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -28,8 +28,8 @@ using ray_core_worker_julia_jll: JuliaGcsClient, Exists, Put, Get,
                                  JuliaFunctionDescriptor, function_descriptor
 
 # https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/ray_constants.py#L122-L123
-const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000
-const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000
+const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000  # in bytes
+const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000  # in bytes
 
 _mib_string(len) = string(div(len, 1024 * 1024), " MiB")
 # https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -27,6 +27,30 @@
 using ray_core_worker_julia_jll: JuliaGcsClient, Exists, Put, Get,
                                  JuliaFunctionDescriptor, function_descriptor
 
+const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000
+const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000
+
+_mib_string(len) = string(div(len, 1024 * 1024), " MiB")
+
+function check_oversized_function(serialized, function_descriptor)
+    len = length(serialized)
+    check_msg = "Check that its definition is not implicitly capturing a large " *
+                "array or other object in scope. Tip: use `Ray.put()` to put large " *
+                "objects in the Ray object store."
+    if len > FUNCTION_SIZE_ERROR_THRESHOLD
+        msg = "The function $(rayjll.CallString(function_descriptor)) is too " *
+              "large ($(_mib_string(len))); FUNCTION_SIZE_ERROR_THRESHOLD=" *
+              "$(_mib_string(FUNCTION_SIZE_ERROR_THRESHOLD)). " * check_msg
+        throw(ArgumentError(msg))
+    elseif length(serialized) > FUNCTION_SIZE_WARN_THRESHOLD
+        msg = "The function $(rayjll.CallString(function_descriptor)) is very " *
+              "large ($(_mib_string(len))). " * check_msg
+        @warn msg
+        # TODO: push warning message to driver if this is a worker
+    end
+    return nothing
+end
+
 # python uses "fun" for the namespace: https://github.com/beacon-biosignals/ray/blob/7ad1f47a9c849abf00ca3e8afc7c3c6ee54cda43/python/ray/_private/ray_constants.py#L380
 # so "jlfun" seems reasonable
 const FUNCTION_MANAGER_NAMESPACE = "jlfun"
@@ -62,6 +86,7 @@ function export_function!(fm::FunctionManager, f, job_id=get_current_job_id())
     else
         @debug "exporting function to GCS store:" fd key f
         val = base64encode(serialize, f)
+        check_oversized_function(val, fd)
         Put(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, val, true, -1)
     end
 end

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -27,24 +27,26 @@
 using ray_core_worker_julia_jll: JuliaGcsClient, Exists, Put, Get,
                                  JuliaFunctionDescriptor, function_descriptor
 
+# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/ray_constants.py#L122-L123
 const FUNCTION_SIZE_WARN_THRESHOLD = 10_000_000
 const FUNCTION_SIZE_ERROR_THRESHOLD = 100_000_000
 
 _mib_string(len) = string(div(len, 1024 * 1024), " MiB")
+# https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L744-L746
+const _check_msg = "Check that its definition is not implicitly capturing a large " *
+                   "array or other object in scope. Tip: use `Ray.put()` to put large " *
+                   "objects in the Ray object store."
 
 function check_oversized_function(serialized, function_descriptor)
     len = length(serialized)
-    check_msg = "Check that its definition is not implicitly capturing a large " *
-                "array or other object in scope. Tip: use `Ray.put()` to put large " *
-                "objects in the Ray object store."
     if len > FUNCTION_SIZE_ERROR_THRESHOLD
         msg = "The function $(rayjll.CallString(function_descriptor)) is too " *
               "large ($(_mib_string(len))); FUNCTION_SIZE_ERROR_THRESHOLD=" *
-              "$(_mib_string(FUNCTION_SIZE_ERROR_THRESHOLD)). " * check_msg
+              "$(_mib_string(FUNCTION_SIZE_ERROR_THRESHOLD)). " * _check_msg
         throw(ArgumentError(msg))
     elseif len > FUNCTION_SIZE_WARN_THRESHOLD
         msg = "The function $(rayjll.CallString(function_descriptor)) is very " *
-              "large ($(_mib_string(len))). " * check_msg
+              "large ($(_mib_string(len))). " * _check_msg
         @warn msg
         # TODO: push warning message to driver if this is a worker
     end

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -51,7 +51,7 @@
     @testset "warn/error for large functions" begin
         # for some reason, using `let` to introduce local scope does not work
         # during test execution to generate a closure, even though it works
-        # locally.  so we use a factory intsead:
+        # locally, so we use a factory instead:
         function bigfactory(size)
             x = rand(UInt8, size)
             return f(y) = y * sum(x)

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -62,7 +62,7 @@
             x = rand(UInt8, Ray.FUNCTION_SIZE_ERROR_THRESHOLD)
             f(y) = y * sum(x)
         end
-        @test_throws export_function!(fm, biggerf, jobid)
+        @test_throws ArgumentError export_function!(fm, biggerf, jobid)
     end
 
     # XXX: this works when run in global scope but unfortunately something about


### PR DESCRIPTION
This is based on the python checks:

thresholds defined here: https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/ray_constants.py#L120-L123

checks executed here: 

https://github.com/beacon-biosignals/ray/blob/1c0cddc478fa33d4c244d3c30aba861a77b0def9/python/ray/_private/utils.py#L725-L767

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303690266615