### PR TITLE
re-use workers for multiple tasks

### DIFF
--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -314,5 +314,6 @@ function start_worker(args=ARGS)
                                     parsed_args["node_ip_address"],
                                     parsed_args["node_manager_port"],
                                     parsed_args["startup_token"],
+                                    parsed_args["runtime_env_hash"],
                                     task_executor)
 end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -149,3 +149,21 @@ end
         end
     end
 end
+
+@testset "many tasks" begin
+    oids = map(1:20) do i
+        s = 20
+        submit_task(s, i) do s, i
+            println(stderr, "task $i running on PID $(getpid()) sleeping $s...")
+            flush(stderr)
+            sleep(s)
+            println("task $i running on PID $(getpid()) slept $s")
+            flush(stderr)
+            # need an Int32 return value for now
+            return Int32(i)
+        end
+    end
+
+    _get(x) = String(take!(ray_core_worker_julia_jll.get(x)))
+    @time map(_get, oids)
+end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -153,7 +153,7 @@ end
 @testset "many tasks" begin
     oids = map(1:20) do i
         s = 20
-        submit_task(s, i) do s, i
+        submit_task((s, i)) do s, i
             pid = getpid()
             println(stderr, "task $i running on PID $pid sleeping $s...")
             flush(stderr)
@@ -164,7 +164,6 @@ end
         end
     end
 
-    _get(x) = String(take!(ray_core_worker_julia_jll.get(x)))
-    @time pids = map(_get, oids)
+    @time pids = Ray.get.(oids)
     @test !allunique(pids)
 end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -154,16 +154,17 @@ end
     oids = map(1:20) do i
         s = 20
         submit_task(s, i) do s, i
-            println(stderr, "task $i running on PID $(getpid()) sleeping $s...")
+            pid = getpid()
+            println(stderr, "task $i running on PID $pid sleeping $s...")
             flush(stderr)
             sleep(s)
-            println("task $i running on PID $(getpid()) slept $s")
+            println("task $i running on PID $pid slept $s")
             flush(stderr)
-            # need an Int32 return value for now
-            return Int32(i)
+            return pid
         end
     end
 
     _get(x) = String(take!(ray_core_worker_julia_jll.get(x)))
-    @time map(_get, oids)
+    @time pids = map(_get, oids)
+    @test !allunique(pids)
 end

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -49,6 +49,7 @@ void initialize_worker(
     std::string node_ip_address,
     int node_manager_port,
     int64_t startup_token,
+    int64_t runtime_env_hash,
     void *julia_task_executor) {
 
     // XXX: Ideally the task_executor would use a `jlcxx::SafeCFunction` and take the expected
@@ -79,6 +80,7 @@ void initialize_worker(
     options.raylet_ip_address = node_ip_address;
     options.metrics_agent_port = -1;
     options.startup_token = startup_token;
+    options.runtime_env_hash = runtime_env_hash;
     options.task_execution_callback =
         [task_executor](
             const rpc::Address &caller_address,

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -161,7 +161,8 @@ end
 #####
 
 function initialize_worker(raylet_socket, store_socket, ray_address, node_ip_address,
-                           node_manager_port, startup_token, task_executor::Function)
+                           node_manager_port, startup_token, runtime_env_hash,
+                           task_executor::Function)
 
     # Note (omus): If you are trying to figure out what type to pass in here I recommend
     # starting with `Any`. This will cause failures at runtime that show up in the
@@ -180,7 +181,7 @@ function initialize_worker(raylet_socket, store_socket, ray_address, node_ip_add
 
     @info "cfunction generated!"
     result = initialize_worker(raylet_socket, store_socket, ray_address, node_ip_address,
-                               node_manager_port, startup_token, cfunc)
+                               node_manager_port, startup_token, runtime_env_hash, cfunc)
 
     @info "worker exiting `ray_core_worker_julia_jll.initialize_worker`"
     return result


### PR DESCRIPTION
the issue was that we were not setting `runtime_env_hash` correctly in the core worker options.

~~the test needs work: currently, it'll spin up more workers to handle the extra load.  informally when I tested htis locally, running the test twice, it does re-use 8 workers (number of CPUs on my macbook air).~~

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303690266614