### PR TITLE
Define `project_dir` once

### DIFF
--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -99,8 +99,6 @@ end
 
 initialize_coreworker_driver(args...) = rayjll.initialize_coreworker_driver(args...)
 
-project_dir() = dirname(Pkg.project().path)
-
 function submit_task(f::Function, args::Tuple; runtime_env::RuntimeEnv=RuntimeEnv())
     export_function!(FUNCTION_MANAGER[], f, get_current_job_id())
     fd = function_descriptor(f)


### PR DESCRIPTION
Fixes a mistake introduced in #41. I am surprised Aqua doesn't catch this:
```
┌ Ray [3f779ece-f0b6-4c4f-a81a-0cb2add9eb95]
│  WARNING: Method definition project_dir() in module Ray at /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/Ray.jl/src/runtime_env.jl:15 overwritten at /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/Ray.jl/src/runtime.jl:102.
│    ** incremental compilation may be fatally broken for this module **
└
```