### PR TITLE
Rename initialize/shutdown functions

### DIFF
--- a/Ray.jl/src/Ray.jl
+++ b/Ray.jl/src/Ray.jl
@@ -13,11 +13,9 @@ using LoggingExtras
 using Pkg
 using Serialization
 
-using ray_core_worker_julia_jll: shutdown_coreworker
-
 import ray_core_worker_julia_jll as rayjll
 
-export start_worker, shutdown_coreworker, submit_task
+export start_worker, submit_task
 
 include("function_manager.jl")
 include("runtime_env.jl")

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -34,8 +34,8 @@ function init()
 
     job_id = rayjll.GetNextJobID(GLOBAL_STATE_ACCESSOR[])
 
-    initialize_coreworker_driver(args..., job_id)
-    atexit(rayjll.shutdown_coreworker)
+    rayjll.initialize_driver(args..., job_id)
+    atexit(rayjll.shutdown_driver)
 
     _init_global_function_manager(gcs_address)
 
@@ -234,11 +234,11 @@ function start_worker(args=ARGS)
 
     @info "Starting Julia worker runtime with args" parsed_args
 
-    return rayjll.start_worker(parsed_args["raylet_socket"],
-                               parsed_args["store_socket"],
-                               parsed_args["address"],
-                               parsed_args["node_ip_address"],
-                               parsed_args["node_manager_port"],
-                               parsed_args["startup_token"],
-                               task_executor)
+    return rayjll.initialize_worker(parsed_args["raylet_socket"],
+                                    parsed_args["store_socket"],
+                                    parsed_args["address"],
+                                    parsed_args["node_ip_address"],
+                                    parsed_args["node_manager_port"],
+                                    parsed_args["startup_token"],
+                                    task_executor)
 end

--- a/Ray.jl/test/runtests.jl
+++ b/Ray.jl/test/runtests.jl
@@ -5,6 +5,7 @@ using Serialization
 using Test
 
 using ray_core_worker_julia_jll
+import ray_core_worker_julia_jll as rayjll
 
 include("setup.jl")
 include("utils.jl")

--- a/Ray.jl/test/utils.jl
+++ b/Ray.jl/test/utils.jl
@@ -18,6 +18,6 @@ function setup_core_worker(body)
     try
         body()
     finally
-        shutdown_coreworker()
+        rayjll.shutdown_driver()
     end
 end

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -1,6 +1,6 @@
 #include "wrapper.h"
 
-void initialize_coreworker_driver(
+void initialize_driver(
     std::string raylet_socket,
     std::string store_socket,
     std::string gcs_address,
@@ -28,14 +28,14 @@ void initialize_coreworker_driver(
     CoreWorkerProcess::Initialize(options);
 }
 
-void shutdown_coreworker() {
+void shutdown_driver() {
     CoreWorkerProcess::Shutdown();
 }
 
 // https://www.kdab.com/how-to-cast-a-function-pointer-to-a-void/
 // https://docs.oracle.com/cd/E19059-01/wrkshp50/805-4956/6j4mh6goi/index.html
 
-void initialize_coreworker_worker(
+void initialize_worker(
     std::string raylet_socket,
     std::string store_socket,
     std::string gcs_address,
@@ -319,11 +319,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
 
     mod.method("GetCurrentJobId", &GetCurrentJobId);
 
-    mod.method("initialize_coreworker_driver", &initialize_coreworker_driver);
-    mod.method("initialize_coreworker_worker", &initialize_coreworker_worker);
-    mod.method("shutdown_coreworker", &shutdown_coreworker);
+    mod.method("initialize_driver", &initialize_driver);
+    mod.method("shutdown_driver", &shutdown_driver);
+    mod.method("initialize_worker", &initialize_worker);
     mod.add_type<ObjectID>("ObjectID");
-
 
     // enum Language
     mod.add_bits<ray::Language>("Language", jlcxx::julia_type("CppEnum"));

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -21,15 +21,6 @@ using ray::core::RayFunction;
 using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
-void initialize_coreworker_driver(
-    std::string raylet_socket,
-    std::string store_socket,
-    std::string gcs_address,
-    std::string node_ip_address,
-    int node_manager_port,
-    JobID job_id);
-
-void shutdown_coreworker();
 ObjectID put(std::shared_ptr<Buffer> buffer);
 std::shared_ptr<Buffer> get(ObjectID object_id);
 std::string ToString(ray::FunctionDescriptor function_descriptor);

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -160,8 +160,8 @@ end
 ##### runtime wrappers
 #####
 
-function start_worker(raylet_socket, store_socket, ray_address, node_ip_address,
-                      node_manager_port, startup_token, task_executor::Function)
+function initialize_worker(raylet_socket, store_socket, ray_address, node_ip_address,
+                           node_manager_port, startup_token, task_executor::Function)
 
     # Note (omus): If you are trying to figure out what type to pass in here I recommend
     # starting with `Any`. This will cause failures at runtime that show up in the
@@ -178,10 +178,9 @@ function start_worker(raylet_socket, store_socket, ray_address, node_ip_address,
     cfunc = @eval @cfunction($(task_executor), Cvoid, ($(arg_types...),))
 
     @info "cfunction generated!"
-    result = initialize_coreworker_worker(raylet_socket, store_socket, ray_address,
-                                          node_ip_address, node_manager_port, startup_token,
-                                          cfunc)
+    result = initialize_worker(raylet_socket, store_socket, ray_address, node_ip_address,
+                               node_manager_port, startup_token, cfunc)
 
-    @info "worker exiting `ray_core_worker_julia_jll.start_worker`"
+    @info "worker exiting `ray_core_worker_julia_jll.initialize_worker`"
     return result
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,4 @@
-using ray_core_worker_julia_jll: initialize_coreworker_driver, shutdown_coreworker, FromInt
+using ray_core_worker_julia_jll: initialize_driver, shutdown_driver, FromInt
 
 function setup_ray_head_node(body)
     prestarted = success(`ray status`)
@@ -29,15 +29,15 @@ function node_manager_port()
 end
 
 function setup_core_worker(body)
-    initialize_coreworker_driver("/tmp/ray/session_latest/sockets/raylet",
-                                 "/tmp/ray/session_latest/sockets/plasma_store",
-                                 "127.0.0.1:6379",
-                                 "127.0.0.1",
-                                 node_manager_port(),
-                                 FromInt(1234))
+    initialize_driver("/tmp/ray/session_latest/sockets/raylet",
+                      "/tmp/ray/session_latest/sockets/plasma_store",
+                      "127.0.0.1:6379",
+                      "127.0.0.1",
+                      node_manager_port(),
+                      FromInt(1234))
     try
         body()
     finally
-        shutdown_coreworker()
+        shutdown_driver()
     end
 end


### PR DESCRIPTION
Quick cleanup pass:

- Rename `initialize_coreworker_driver` to `initialize_driver`
- Rename `initialize_coreworker_worker` to `initialize_worker`
- Rename `shutdown_coreworker` to `shutdown_driver`
- Rename `ray_core_worker_julia_jll.start_worker` to `ray_core_worker_julia_jll.initialize_worker`