### PR TITLE
Use high-level get in tests

### DIFF
--- a/Ray.jl/Project.toml
+++ b/Ray.jl/Project.toml
@@ -23,9 +23,7 @@ ray_core_worker_julia_jll = "0.1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Distributed", "Pkg", "Test"]
+test = ["Aqua", "Test"]

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -73,6 +73,7 @@
     # reasons that are completely unrelated to the actual functionality being
     # tested).
 
+    # using Distributed
     # try
     #     worker = only(addprocs(1; exeflags="--project"))
     #     Distributed.remotecall_eval(Main, worker, quote

--- a/Ray.jl/test/runtests.jl
+++ b/Ray.jl/test/runtests.jl
@@ -1,10 +1,7 @@
 using Aqua
-using Distributed
 using Ray
-using Serialization
 using Test
 
-using ray_core_worker_julia_jll
 import ray_core_worker_julia_jll as rayjll
 
 include("setup.jl")
@@ -20,8 +17,8 @@ include("utils.jl")
     setup_ray_head_node() do
         include("function_manager.jl")
         setup_core_worker() do
-            include("task.jl")
             include("object_store.jl")
+            include("task.jl")
         end
     end
 end


### PR DESCRIPTION
Follow up to #43 to have the task tests use the high-level `Ray.get`/`Ray.put`. This change allowed us to remove some loaded packages in the tests.

Additionally, I removed the unused test dependency on Distributed and Pkg which were introduced in #19.