### PR TITLE
Silent CxxWrap finalizer

### DIFF
--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -332,7 +332,7 @@ namespace jlcxx
     {
         static void finalize(T* to_delete)
         {
-            std::cout << "calling delete on: " << to_delete << std::endl;
+            // std::cout << "calling delete on: " << to_delete << std::endl;
             delete to_delete;
         }
     };

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -327,15 +327,17 @@ namespace jlcxx
     // Custom finalizer to show what is being deleted. Can be useful in tracking down
     // segmentation faults due to double deallocations
     // https://github.com/JuliaInterop/CxxWrap.jl/tree/main#overriding-finalization-behavior
+    /*
     template<typename T>
     struct Finalizer<T, SpecializedFinalizer>
     {
         static void finalize(T* to_delete)
         {
-            // std::cout << "calling delete on: " << to_delete << std::endl;
+            std::cout << "calling delete on: " << to_delete << std::endl;
             delete to_delete;
         }
     };
+    */
 }
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod)


### PR DESCRIPTION
Disabling the output on our CxxWrap finalizer which let's us know which objects are being deleted. It's still useful code when encountering segmentation faults which is why I've opted to comment the code out for now instead of delete it.