### PR TITLE
Grab bag of minor changes

### DIFF
--- a/Ray.jl/src/Ray.jl
+++ b/Ray.jl/src/Ray.jl
@@ -14,7 +14,7 @@ using LoggingExtras
 using Pkg
 using Serialization
 
-import ray_core_worker_julia_jll as rayjll
+import ray_core_worker_julia_jll as ray_jll
 
 export start_worker, submit_task, @ray_import
 

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -6,14 +6,14 @@ the `data` with [`Ray.get`](@ref).
 """
 function put(data)
     buffer = _put(data)
-    return rayjll.put(buffer)
+    return ray_jll.put(buffer)
 end
 
 function _put(data)
     bytes = Vector{UInt8}()
     io = IOBuffer(bytes; write=true)
     serialize(io, data)
-    return rayjll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
+    return ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
 end
 
 """
@@ -26,8 +26,8 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(oid::rayjll.ObjectIDAllocated) = _get(take!(rayjll.get(oid)))
-get(obj::SharedPtr{rayjll.RayObject}) = _get(take!(rayjll.GetData(obj[])))
+get(oid::ray_jll.ObjectIDAllocated) = _get(take!(ray_jll.get(oid)))
+get(obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(obj[])))
 get(x) = x
 
 function _get(data::Vector{UInt8})

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -5,13 +5,15 @@ Store `data` in the object store. Returns an object reference which can used to 
 the `data` with [`Ray.get`](@ref).
 """
 function put(data)
+    buffer = _put(data)
+    return rayjll.put(buffer)
+end
+
+function _put(data)
     bytes = Vector{UInt8}()
     io = IOBuffer(bytes; write=true)
     serialize(io, data)
-    buffer_ptr = Ptr{Nothing}(pointer(bytes))
-    buffer_size = sizeof(bytes)
-    buffer = rayjll.LocalMemoryBuffer(buffer_ptr, buffer_size, true)
-    return rayjll.put(buffer)
+    return rayjll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
 end
 
 """

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -221,10 +221,7 @@ function task_executor(ray_function, returns_ptr, task_args_ptr, task_name,
     @info "Result: $result"
 
     # TODO: support multiple return values
-    buffer_data = Vector{UInt8}(sprint(serialize, result))
-    buffer_size = sizeof(buffer_data)
-    buffer = rayjll.LocalMemoryBuffer(buffer_data, buffer_size, true)
-    push!(returns, buffer)
+    push!(returns, _put(result))
 
     return nothing
 end

--- a/Ray.jl/src/runtime_env.jl
+++ b/Ray.jl/src/runtime_env.jl
@@ -59,7 +59,7 @@ end
 # serialization. Mostly this matters if Ray serializes the same message with both formats.
 function _serialize(job_config::JobConfig)
     job_config_json = JSON3.write(json_dict(job_config))
-    return rayjll.serialize_job_config_json(job_config_json)
+    return ray_jll.serialize_job_config_json(job_config_json)
 end
 
 function process_import_statements(ex::Expr)

--- a/Ray.jl/test/runtests.jl
+++ b/Ray.jl/test/runtests.jl
@@ -3,7 +3,7 @@ using Ray
 using Serialization
 using Test
 
-import ray_core_worker_julia_jll as rayjll
+import ray_core_worker_julia_jll as ray_jll
 
 include("setup.jl")
 include("utils.jl")

--- a/Ray.jl/test/utils.jl
+++ b/Ray.jl/test/utils.jl
@@ -18,7 +18,7 @@ function setup_core_worker(body)
     try
         body()
     finally
-        rayjll.shutdown_driver()
+        ray_jll.shutdown_driver()
     end
 end
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -136,6 +136,41 @@ std::vector<std::shared_ptr<RayObject>> cast_to_task_args(void *ptr) {
     return *rayobj_ptr;
 }
 
+ObjectID _submit_task(const ray::JuliaFunctionDescriptor &jl_func_descriptor,
+                      const std::vector<ObjectID> &object_ids,
+                      const std::string &serialized_runtime_env_info) {
+
+    auto &worker = CoreWorkerProcess::GetCoreWorker();
+
+    ray::FunctionDescriptor func_descriptor = std::make_shared<ray::JuliaFunctionDescriptor>(jl_func_descriptor);
+    RayFunction func(Language::JULIA, func_descriptor);
+
+    std::vector<std::unique_ptr<TaskArg>> args;
+    for (auto & obj_id : object_ids) {
+        args.emplace_back(new TaskArgByReference(obj_id, worker.GetRpcAddress(), /*call-site*/""));
+    }
+
+    // TaskOptions: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/common.h#L62-L87
+    TaskOptions options;
+    options.serialized_runtime_env_info = serialized_runtime_env_info;
+
+    rpc::SchedulingStrategy scheduling_strategy;
+    scheduling_strategy.mutable_default_scheduling_strategy();
+
+    // https://github.com/ray-project/ray/blob/4e9e8913a6c9cc3533fe27478f30bdee1deffaf5/src/ray/core_worker/test/core_worker_test.cc#L79
+    auto return_refs = worker.SubmitTask(
+        func,
+        args,
+        options,
+        /*max_retries=*/0,
+        /*retry_exceptions=*/false,
+        scheduling_strategy,
+        /*debugger_breakpoint=*/""
+    );
+
+    return ObjectRefsToIds(return_refs)[0];
+}
+
 // TODO: probably makes more sense to have a global worker rather than calling
 // GetCoreWorker() over and over again...(here and below)
 JobID GetCurrentJobId() {
@@ -269,41 +304,6 @@ bool JuliaGcsClient::Exists(const std::string &ns,
         throw std::runtime_error(status.ToString());
     }
     return exists;
-}
-
-ObjectID _submit_task(const ray::JuliaFunctionDescriptor &jl_func_descriptor,
-                      const std::vector<ObjectID> &object_ids,
-                      const std::string &serialized_runtime_env_info) {
-
-    auto &worker = CoreWorkerProcess::GetCoreWorker();
-
-    ray::FunctionDescriptor func_descriptor = std::make_shared<ray::JuliaFunctionDescriptor>(jl_func_descriptor);
-    RayFunction func(Language::JULIA, func_descriptor);
-
-    std::vector<std::unique_ptr<TaskArg>> args;
-    for (auto & obj_id : object_ids) {
-        args.emplace_back(new TaskArgByReference(obj_id, worker.GetRpcAddress(), /*call-site*/""));
-    }
-
-    // TaskOptions: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/common.h#L62-L87
-    TaskOptions options;
-    options.serialized_runtime_env_info = serialized_runtime_env_info;
-
-    rpc::SchedulingStrategy scheduling_strategy;
-    scheduling_strategy.mutable_default_scheduling_strategy();
-
-    // https://github.com/ray-project/ray/blob/4e9e8913a6c9cc3533fe27478f30bdee1deffaf5/src/ray/core_worker/test/core_worker_test.cc#L79
-    auto return_refs = worker.SubmitTask(
-        func,
-        args,
-        options,
-        /*max_retries=*/0,
-        /*retry_exceptions=*/false,
-        scheduling_strategy,
-        /*debugger_breakpoint=*/""
-    );
-
-    return ObjectRefsToIds(return_refs)[0];
 }
 
 Status report_error(std::string *application_error,


### PR DESCRIPTION
- Create an internal `_put` function which creates a `LocalMemoryBuffer`
- Move the `_submit_task` C++ function closer to the `task_executor_callback` as they are closely related and typically are changed at the same time
- Rename `rayjll` to `ray_jll`