### PR TITLE
set logs_dir in options and default to file logging

### DIFF
--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -63,7 +63,7 @@ end
 const FUNCTION_MANAGER = Ref{FunctionManager}()
 
 function _init_global_function_manager(gcs_address)
-    @info "connecting function manager to GCS at $gcs_address..."
+    @info "Connecting function manager to GCS at $gcs_address..."
     gcs_client = ray_jll.JuliaGcsClient(gcs_address)
     ray_jll.Connect(gcs_client)
     FUNCTION_MANAGER[] = FunctionManager(; gcs_client,
@@ -77,13 +77,13 @@ end
 function export_function!(fm::FunctionManager, f, job_id=get_current_job_id())
     fd = ray_jll.function_descriptor(f)
     key = function_key(fd, job_id)
-    @debug "exporting function to function store:" fd key
+    @debug "Exporting function to function store:" fd key
     # DFK: I _think_ the string memory may be mangled if we don't `deepcopy`. Not sure but
     # it can't hurt
     if ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, deepcopy(key), -1)
-        @debug "function already present in GCS store:" fd key f
+        @debug "Function already present in GCS store:" fd key f
     else
-        @debug "exporting function to GCS store:" fd key f
+        @debug "Exporting function to GCS store:" fd key f
         val = base64encode(serialize, f)
         check_oversized_function(val, fd)
         ray_jll.Put(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, val, true, -1)
@@ -111,7 +111,7 @@ function import_function!(fm::FunctionManager, fd::ray_jll.JuliaFunctionDescript
                           job_id=get_current_job_id())
     return get!(fm.functions, fd.function_hash) do
         key = function_key(fd, job_id)
-        @debug "function not found locally, retrieving from function store" fd key
+        @debug "Function not found locally, retrieving from function store" fd key
         val = ray_jll.Get(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, -1)
         try
             io = IOBuffer()

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -60,7 +60,7 @@ function init(runtime_env::Union{RuntimeEnv,Nothing}=nothing;
 
     # resolve symlink
     session_dir = realpath(session_dir)
-    log_to_stderr = get(ENV, LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE, "0") == "1"
+    log_to_stderr = Base.get(ENV, LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE, "0") == "1"
     logs_dir = log_to_stderr ? "" : joinpath(session_dir, "logs")
 
     if isnothing(runtime_env)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -48,6 +48,10 @@ const LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE = "RAY_LOG_TO_STDERR"
 
 function default_log_dir(session_dir)
     redirect_logs = Base.get(ENV, LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE, "0") == "1"
+    # realpath() resolves relative paths and symlinks, including the default
+    # `/tmp/ray/session_latest/`.  this is defense against folks potentially
+    # starting multiple ray sessions locally, which could cause the logs path to
+    # change out from under us if we use the symlink directly.
     return redirect_logs ? "" : realpath(joinpath(session_dir, "logs"))
 end
 

--- a/Ray.jl/test/runtests.jl
+++ b/Ray.jl/test/runtests.jl
@@ -21,6 +21,7 @@ include("utils.jl")
     setup_ray_head_node() do
         include("function_manager.jl")
         setup_core_worker() do
+            include("runtime.jl")
             include("object_store.jl")
             include("task.jl")
         end

--- a/Ray.jl/test/runtime.jl
+++ b/Ray.jl/test/runtime.jl
@@ -1,5 +1,5 @@
-@testest "control logs_dir" begin
-    @testest "defaul logs_dir" begin
+@testset "control logs_dir" begin
+    @testset "defaul logs_dir" begin
         # we're running this after `init` has been called, so logs should exist already:
         logs = readdir("/tmp/ray/session_latest/logs"; join=true)
         @test any(contains("julia-core-driver"), logs)

--- a/Ray.jl/test/runtime.jl
+++ b/Ray.jl/test/runtime.jl
@@ -51,8 +51,8 @@
         out = IOBuffer()
         err = IOBuffer()
         run(pipeline(cmd; stdout=out, stderr=err))
-        logs = String(take!(err))
-        @test contains(logs, "Constructing CoreWorkerProcess")
+        stderr_logs = String(take!(err))
+        @test contains(stderr_logs, "Constructing CoreWorkerProcess")
     end
 
     @testset "kwarg takes precedence over env var" begin

--- a/Ray.jl/test/runtime.jl
+++ b/Ray.jl/test/runtime.jl
@@ -40,4 +40,19 @@
         logs = String(take!(err))
         @test contains(logs, "Constructing CoreWorkerProcess")
     end
+
+    @testset "log to stderr: env var" begin
+        code = quote
+            using Ray
+            ENV[Ray.LOGGING_REDIRECT_STDERR_ENVIRONMENT_VARIABLE] = "1"
+            Ray.init()
+        end
+        cmd = `$(Base.julia_cmd()) --project=$(Ray.project_dir()) -e $code`
+        out = IOBuffer()
+        err = IOBuffer()
+        run(pipeline(cmd; stdout=out, stderr=err))
+        logs = String(take!(err))
+        @test contains(logs, "Constructing CoreWorkerProcess")
+    end
+
 end

--- a/Ray.jl/test/runtime.jl
+++ b/Ray.jl/test/runtime.jl
@@ -1,5 +1,5 @@
 @testset "control logs_dir" begin
-    @testset "defaul logs_dir" begin
+    @testset "default logs_dir" begin
         # we're running this after `init` has been called, so logs should exist already:
         logs = readdir("/tmp/ray/session_latest/logs"; join=true)
         @test any(contains("julia-core-driver"), logs)

--- a/Ray.jl/test/runtime.jl
+++ b/Ray.jl/test/runtime.jl
@@ -37,8 +37,8 @@
         out = IOBuffer()
         err = IOBuffer()
         run(pipeline(cmd; stdout=out, stderr=err))
-        logs = String(take!(err))
-        @test contains(logs, "Constructing CoreWorkerProcess")
+        stderr_logs = String(take!(err))
+        @test contains(stderr_logs, "Constructing CoreWorkerProcess")
     end
 
     @testset "log to stderr: env var" begin

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -20,7 +20,7 @@ void initialize_driver(
     // get next job id instead
     options.job_id = job_id;
     options.gcs_options = gcs::GcsClientOptions(gcs_address);
-    options.enable_logging = logs_dir.empty();
+    options.enable_logging = !logs_dir.empty();
     options.log_dir = logs_dir;
     // options.install_failure_signal_handler = true;
     options.node_ip_address = node_ip_address;

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -7,6 +7,7 @@ void initialize_driver(
     std::string node_ip_address,
     int node_manager_port,
     JobID job_id,
+    std::string logs_dir,
     const std::string &serialized_job_config) {
     // RAY_LOG_ENABLED(DEBUG);
 
@@ -19,7 +20,8 @@ void initialize_driver(
     // get next job id instead
     options.job_id = job_id;
     options.gcs_options = gcs::GcsClientOptions(gcs_address);
-    // options.enable_logging = true;
+    options.enable_logging = logs_dir.empty();
+    options.log_dir = logs_dir;
     // options.install_failure_signal_handler = true;
     options.node_ip_address = node_ip_address;
     options.node_manager_port = node_manager_port;

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -35,6 +35,7 @@ function setup_core_worker(body)
                       "127.0.0.1",
                       node_manager_port(),
                       FromInt(1234),
+                      "/tmp/ray/session_latest/logs/",
                       "")
     try
         body()


### PR DESCRIPTION
This fixes the issue where all teh core worker logs (including GCS event stats every 1s) were being written to stderr.

I did a tiny bit of refactoring to allow the session dir and logs dir to be passed in as arguments to `Ray.init()`.  Logging to stderr can be turned back on by either passing in `logs_dir=""`, or by setting `RAY_LOG_TO_STDERR=1` (which matches the python driver).  not totally wedded to that but figured it was good to be consistent.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205360251811528