### PR TITLE
Fix "Deadline Exceeded" exception

### DIFF
--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -90,7 +90,7 @@ function export_function!(fm::FunctionManager, f, job_id=get_current_job_id())
     end
 end
 
-function wait_for_function(fm::FunctionManager, fd::ray_jll.JuliaFunctionDescriptor,
+function timedwait_for_function(fm::FunctionManager, fd::ray_jll.JuliaFunctionDescriptor,
                            job_id=get_current_job_id(); timeout_s=10)
     key = function_key(fd, job_id)
     status = try

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -95,9 +95,9 @@ function wait_for_function(fm::FunctionManager, fd::ray_jll.JuliaFunctionDescrip
                            pollint_s=0.01, timeout_s=10)
     key = function_key(fd, job_id)
     status = timedwait(timeout_s; pollint=pollint_s) do
-        # timeout the Exists query to the same timeout we use here so we don't
-        # deadlock.
-        ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, timeout_s)
+        # Set Exists to not block by using a negative timeout. If we set a non-negative
+        # timeout then this function can throw "Deadline Exceeded" exceptions.
+        ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, -1)
     end
     return status
 end

--- a/Ray.jl/src/function_manager.jl
+++ b/Ray.jl/src/function_manager.jl
@@ -91,10 +91,10 @@ function export_function!(fm::FunctionManager, f, job_id=get_current_job_id())
 end
 
 function wait_for_function(fm::FunctionManager, fd::ray_jll.JuliaFunctionDescriptor,
-                           job_id=get_current_job_id(); timeout=10)
+                           job_id=get_current_job_id(); timeout_s=10)
     key = function_key(fd, job_id)
     status = try
-        exists = ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, timeout)
+        exists = ray_jll.Exists(fm.gcs_client, FUNCTION_MANAGER_NAMESPACE, key, timeout_s)
         exists ? :ok : :timed_out
     catch e
         if e isa ErrorException && contains(e.msg, "Deadline Exceeded")

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -13,14 +13,14 @@
     export_function!(fm, f, jobid)
 
     fd = function_descriptor(f)
-    @test wait_for_function(fm, fd, jobid; timeout=10) == :ok
+    @test wait_for_function(fm, fd, jobid; timeout_s=10) == :ok
     f2 = import_function!(fm, fd, jobid)
 
     @test f2.(1:10) == f.(1:10)
 
     mfd = function_descriptor(MyMod.f)
     @test_throws ErrorException import_function!(fm, mfd, jobid)
-    @test wait_for_function(fm, mfd, jobid; timeout=1) == :timed_out
+    @test wait_for_function(fm, mfd, jobid; timeout_s=1) == :timed_out
     export_function!(fm, MyMod.f, jobid)
 
     # can import the function even when it's aliased in another module:

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -13,14 +13,14 @@
     export_function!(fm, f, jobid)
 
     fd = function_descriptor(f)
-    @test wait_for_function(fm, fd, jobid; timeout_s=10) == :ok
+    @test wait_for_function(fm, fd, jobid; timeout=10) == :ok
     f2 = import_function!(fm, fd, jobid)
 
     @test f2.(1:10) == f.(1:10)
 
     mfd = function_descriptor(MyMod.f)
     @test_throws ErrorException import_function!(fm, mfd, jobid)
-    @test wait_for_function(fm, mfd, jobid; timeout_s=1) == :timed_out
+    @test wait_for_function(fm, mfd, jobid; timeout=1) == :timed_out
     export_function!(fm, MyMod.f, jobid)
 
     # can import the function even when it's aliased in another module:

--- a/Ray.jl/test/function_manager.jl
+++ b/Ray.jl/test/function_manager.jl
@@ -1,5 +1,5 @@
 @testset "function manager" begin
-    using Ray: FunctionManager, export_function!, import_function!, wait_for_function
+    using Ray: FunctionManager, export_function!, import_function!, timedwait_for_function
     using ray_core_worker_julia_jll: JuliaGcsClient, Connect, function_descriptor, JuliaFunctionDescriptor, Exists
 
     client = JuliaGcsClient("127.0.0.1:6379")
@@ -13,14 +13,14 @@
     export_function!(fm, f, jobid)
 
     fd = function_descriptor(f)
-    @test wait_for_function(fm, fd, jobid; timeout_s=10) == :ok
+    @test timedwait_for_function(fm, fd, jobid; timeout_s=10) == :ok
     f2 = import_function!(fm, fd, jobid)
 
     @test f2.(1:10) == f.(1:10)
 
     mfd = function_descriptor(MyMod.f)
     @test_throws ErrorException import_function!(fm, mfd, jobid)
-    @test wait_for_function(fm, mfd, jobid; timeout_s=1) == :timed_out
+    @test timedwait_for_function(fm, mfd, jobid; timeout_s=1) == :timed_out
     export_function!(fm, MyMod.f, jobid)
 
     # can import the function even when it's aliased in another module:


### PR DESCRIPTION
Fixes this exception I was seeing regularly on my MacBook:
```julia
function manager: Error During Test at /Users/cvogt/.julia/dev/ray_core_worker_julia_jll/Ray.jl/test/function_manager.jl:23
  Test threw exception
  Expression: wait_for_function(fm, mfd, jobid; timeout_s = 1) == :timed_out
  Unknown: Deadline Exceeded
  Stacktrace:
   [1] Exists(arg1::Union{JuliaGcsClient, CxxWrap.CxxWrapCore.CxxRef{<:JuliaGcsClient}}, arg2::Union{AbstractString, CxxWrap.CxxWrapCore.ConstCxxRef{<:CxxWrap.StdLib.StdString}, CxxWrap.CxxWrapCore.CxxRef{<:CxxWrap.StdLib.StdString}}, arg3::Union{AbstractString, CxxWrap.CxxWrapCore.ConstCxxRef{<:CxxWrap.StdLib.StdString}, CxxWrap.CxxWrapCore.CxxRef{<:CxxWrap.StdLib.StdString}}, arg4::Integer)
     @ ray_core_worker_julia_jll ~/.julia/packages/CxxWrap/aXNBY/src/CxxWrap.jl:624
   [2] #3
     @ ~/.julia/dev/ray_core_worker_julia_jll/Ray.jl/src/function_manager.jl:100 [inlined]
   [3] timedwait(testcb::Ray.var"#3#4"{Int64, FunctionManager, String}, timeout::Int64; pollint::Float64)
     @ Base ./asyncevent.jl:320
   [4] timedwait
     @ ./asyncevent.jl:311 [inlined]
   [5] #wait_for_function#2
     @ ~/.julia/dev/ray_core_worker_julia_jll/Ray.jl/src/function_manager.jl:97 [inlined]
   [6] macro expansion
     @ ~/Development/Julia/aarch64/1.9/usr/share/julia/stdlib/v1.9/Test/src/Test.jl:478 [inlined]
   [7] macro expansion
     @ ~/.julia/dev/ray_core_worker_julia_jll/Ray.jl/test/function_manager.jl:23 [inlined]
   [8] macro expansion
     @ ~/Development/Julia/aarch64/1.9/usr/share/julia/stdlib/v1.9/Test/src/Test.jl:1498 [inlined]
   [9] top-level scope
     @ ~/.julia/dev/ray_core_worker_julia_jll/Ray.jl/test/function_manager.jl:2
```
