### PR TITLE
add timeout to `ray_jll.get` and make `Ray.get` short-poll every 100ms

### DIFF
--- a/Ray.jl/src/Ray.jl
+++ b/Ray.jl/src/Ray.jl
@@ -7,7 +7,7 @@ module Ray
 
 using ArgParse
 using Base64
-using CxxWrap: CxxPtr, CxxRef, StdVector
+using CxxWrap: CxxPtr, CxxRef, StdVector, isnull
 using CxxWrap.StdLib: SharedPtr
 using JSON3
 using Logging

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -34,14 +34,7 @@ function get(oid::ray_jll.ObjectIDAllocated)
     return get(ray_obj)
 end
 
-function get(ray_obj::SharedPtr{ray_jll.RayObject})
-    if isnull(ray_obj[])
-        return nothing
-    else
-        return _get(take!(ray_jll.GetData(ray_obj[])))
-    end
-end
-
+get(ray_obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(ray_obj[])))
 get(x; kwargs...) = x
 
 function _get(bytes)

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -14,7 +14,7 @@ end
 put(obj_ref::ObjectRef) = obj_ref
 
 """
-    Ray.get(object_id::ObjectIDAllocated; timeout_ms=-1)
+    Ray.get(object_id::ObjectIDAllocated)
 
 Retrieves the data associated with the `object_id` from the object store.  This
 method is blocking until the data is available in the local object store, even
@@ -23,10 +23,20 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(obj_ref::ObjectRef) = get(obj_ref.oid)
-get(oid::ray_jll.ObjectIDAllocated; timeout_ms::Int=-1) = get(ray_jll.get(oid, timeout_ms))
+get(obj_ref::ObjectRef; pollint_seconds=0.1) = get(obj_ref.oid; pollint_seconds)
+function get(oid::ray_jll.ObjectIDAllocated; pollint_seconds=0.1)
+    # we poll here with a 0 timeout in order to provide immediate return and
+    # create a yield point so this is `@async` friendly
+    timeout_ms = 0
+    result = get(ray_jll.get(oid, timeout_ms))
+    while result === nothing
+        sleep(pollint_seconds)
+        result = get(ray_jll.get(oid, timeout_ms))
+    end
+    return result
+end
 get(ray_obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(ray_obj[])))
-get(x) = x
+get(x; kwargs...) = x
 
 function _get(bytes)
     result = deserialize_from_bytes(bytes)

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -25,16 +25,13 @@ captured exception will be thrown on `get`.
 """
 get(obj_ref::ObjectRef; pollint_seconds=0.1) = get(obj_ref.oid; pollint_seconds)
 
-function get(oid::ray_jll.ObjectIDAllocated; pollint_seconds=0.1)
-    # we poll here with a 0 timeout in order to provide immediate return and
-    # create a yield point so this is `@async` friendly
-    timeout_ms = 0
-    result = get(ray_jll.get(oid, timeout_ms))
-    while result === nothing
-        sleep(pollint_seconds)
-        result = get(ray_jll.get(oid, timeout_ms))
+function get(oid::ray_jll.ObjectIDAllocated)
+    local ray_obj
+    while true
+        ray_obj = ray_jll.get(oid, 0)
+        isnull(ray_obj[]) ? sleep(0.1) : break
     end
-    return result
+    return get(ray_obj)
 end
 
 function get(ray_obj::SharedPtr{ray_jll.RayObject})

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -11,7 +11,7 @@ function put(data)
 end
 
 """
-    Ray.get(object_id::ObjectIDAllocated)
+    Ray.get(object_id::ObjectIDAllocated; timeout_ms=-1)
 
 Retrieves the data associated with the `object_id` from the object store.  This
 method is blocking until the data is available in the local object store, even

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -23,7 +23,7 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(obj_ref::ObjectRef; pollint_seconds=0.1) = get(obj_ref.oid; pollint_seconds)
+get(obj_ref::ObjectRef) = get(obj_ref.oid)
 
 function get(oid::ray_jll.ObjectIDAllocated)
     local ray_obj
@@ -35,7 +35,7 @@ function get(oid::ray_jll.ObjectIDAllocated)
 end
 
 get(ray_obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(ray_obj[])))
-get(x; kwargs...) = x
+get(x) = x
 
 function _get(bytes)
     result = deserialize_from_bytes(bytes)

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -16,7 +16,7 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(oid::ray_jll.ObjectIDAllocated) = _get(ray_jll.get(oid))
+get(oid::ray_jll.ObjectIDAllocated; timeout_ms::Int=-1) = _get(ray_jll.get(oid, timeout_ms))
 get(obj::SharedPtr{ray_jll.RayObject}) = _get(ray_jll.GetData(obj[]))
 get(x) = x
 
@@ -35,5 +35,7 @@ function to_serialized_buffer(data)
 end
 
 function from_serialized_buffer(buffer)
-    result = deserialize(IOBuffer(take!(buffer)))
+    bytes = take!(buffer)
+    bytes === nothing && return nothing
+    result = deserialize(IOBuffer(bytes))
 end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -177,6 +177,19 @@ end
     @test !isempty(intersect(pids, pids2))
 end
 
+# do this after the many tasks testset so we have workers warmed up
+@testset "Async waiting on task" begin
+    sleep_t = t -> (sleep(t); t)
+    results = []
+    t1 = @async push!(results, Ray.get(submit_task(sleep_t, (10,))))
+    t2 = @async push!(results, Ray.get(submit_task(sleep_t, (1,))))
+
+    wait(t1)
+    wait(t2)
+
+    @test results == [1, 10]
+end
+
 @testset "task resource requests" begin
     function gimme_resources()
         resources = ray_jll.get_task_required_resources()

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -202,13 +202,16 @@ ObjectID put(std::shared_ptr<Buffer> buffer) {
 }
 
 // https://github.com/ray-project/ray/blob/a4a8389a3053b9ef0e8409a55e2fae618bfca2be/src/ray/core_worker/test/core_worker_test.cc#L210-L220
-std::shared_ptr<Buffer> get(ObjectID object_id) {
+std::shared_ptr<Buffer> get(ObjectID object_id, int64_t timeout_ms) {
     auto &driver = CoreWorkerProcess::GetCoreWorker();
 
     // Retrieve our data from the object store
     std::vector<std::shared_ptr<RayObject>> results;
     std::vector<ObjectID> get_obj_ids = {object_id};
-    RAY_CHECK_OK(driver.Get(get_obj_ids, -1, &results));
+    auto status = driver.Get(get_obj_ids, timeout_ms, &results);
+    if (!status.ok()) {
+        return nullptr;
+    }
 
     std::shared_ptr<RayObject> result = results[0];
     if (result == nullptr) {

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -22,7 +22,7 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 ObjectID put(std::shared_ptr<Buffer> buffer);
-std::shared_ptr<Buffer> get(ObjectID object_id);
+std::shared_ptr<Buffer> get(ObjectID object_id, int64_t timeout_ms);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -157,7 +157,6 @@ end
 #####
 
 function Base.take!(buffer::CxxWrap.CxxWrapCore.SmartPointer{<:Buffer})
-    isnull(buffer[]) && return nothing
     buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
     buffer_size = Size(buffer[])
     vec = Vector{UInt8}(undef, buffer_size)

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -136,6 +136,7 @@ function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
 end
 
 function Base.take!(buffer::CxxWrap.CxxWrapCore.SmartPointer{<:Buffer})
+    isnull(buffer[]) && return nothing
     buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
     buffer_size = Size(buffer[])
     vec = Vector{UInt8}(undef, buffer_size)

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -7,7 +7,7 @@ using ray_core_worker_julia_jll: put, get
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
-        buffer = get(obj_ref)
+        buffer = get(obj_ref, -1)
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])
         T = eltype(data)
@@ -23,7 +23,7 @@ using ray_core_worker_julia_jll: put, get
         data = "Greetings from Julia!"
         obj_ref = put(LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true))
 
-        buffer = get(obj_ref)
+        buffer = get(obj_ref, -1)
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])
         v = Vector{UInt8}(undef, buffer_size)


### PR DESCRIPTION
This preserves the high-level behavior of `Ray.get` (blocks indefinitely until object is ready) while doing so in a way that does not hard lock the julia session.  Ultimately we'll also want to do something similar for `wait` (without actually trying to _fetch_ the results) but this is a fine stopgap for now.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205391426815967