### PR TITLE
Introduce `ObjectRef`

### DIFF
--- a/Ray.jl/src/Ray.jl
+++ b/Ray.jl/src/Ray.jl
@@ -17,12 +17,13 @@ using Serialization
 
 import ray_core_worker_julia_jll as ray_jll
 
-export start_worker, submit_task, @ray_import
+export start_worker, submit_task, @ray_import, ObjectRef
 
 include("function_manager.jl")
 include("runtime_env.jl")
 include("remote_function.jl")
 include("runtime.jl")
+include("object_ref.jl")
 include("object_store.jl")
 
 end

--- a/Ray.jl/src/object_ref.jl
+++ b/Ray.jl/src/object_ref.jl
@@ -1,0 +1,14 @@
+struct ObjectRef
+    oid::ray_jll.ObjectIDAllocated
+end
+
+ObjectRef(hex_str::AbstractString) = ObjectRef(ray_jll.FromHex(ray_jll.ObjectID, hex_str))
+Base.string(obj_ref::ObjectRef) = String(ray_jll.Hex(obj_ref.oid))
+Base.:(==)(a::ObjectRef, b::ObjectRef) = string(a) == string(b)
+
+function Base.show(io::IO, obj_ref::ObjectRef)
+    write(io, "ObjectRef(\"", string(obj_ref), "\")")
+    return nothing
+end
+
+Base.convert(::Type{ray_jll.ObjectID}, obj_ref::ObjectRef) = obj_ref.oid

--- a/Ray.jl/src/object_ref.jl
+++ b/Ray.jl/src/object_ref.jl
@@ -10,5 +10,3 @@ function Base.show(io::IO, obj_ref::ObjectRef)
     write(io, "ObjectRef(\"", hex_identifier(obj_ref), "\")")
     return nothing
 end
-
-Base.convert(::Type{ray_jll.ObjectID}, obj_ref::ObjectRef) = obj_ref.oid

--- a/Ray.jl/src/object_ref.jl
+++ b/Ray.jl/src/object_ref.jl
@@ -3,11 +3,11 @@ struct ObjectRef
 end
 
 ObjectRef(hex_str::AbstractString) = ObjectRef(ray_jll.FromHex(ray_jll.ObjectID, hex_str))
-Base.string(obj_ref::ObjectRef) = String(ray_jll.Hex(obj_ref.oid))
-Base.:(==)(a::ObjectRef, b::ObjectRef) = string(a) == string(b)
+hex_identifier(obj_ref::ObjectRef) = String(ray_jll.Hex(obj_ref.oid))
+Base.:(==)(a::ObjectRef, b::ObjectRef) = hex_identifier(a) == hex_identifier(b)
 
 function Base.show(io::IO, obj_ref::ObjectRef)
-    write(io, "ObjectRef(\"", string(obj_ref), "\")")
+    write(io, "ObjectRef(\"", hex_identifier(obj_ref), "\")")
     return nothing
 end
 

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -5,6 +5,7 @@ Store `data` in the object store. Returns an object reference which can used to 
 the `data` with [`Ray.get`](@ref).
 """
 put(data) = ObjectRef(ray_jll.put(to_serialized_buffer(data)))
+put(obj_ref::ObjectRef) = obj_ref
 
 """
     Ray.get(object_id::ObjectIDAllocated)

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -22,7 +22,7 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(obj_ref::ObjectRef) = _get(take!(ray_jll.get(convert(ray_jll.ObjectID, obj_ref.oid))))
+get(obj_ref::ObjectRef) = _get(take!(ray_jll.get(obj_ref.oid)))
 get(oid::ray_jll.ObjectIDAllocated) = _get(take!(ray_jll.get(oid)))
 get(obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(obj[])))
 get(x) = x

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -1,10 +1,10 @@
 """
-    Ray.put(data) -> ObjectIDAllocated
+    Ray.put(data) -> ObjectRef
 
 Store `data` in the object store. Returns an object reference which can used to retrieve
 the `data` with [`Ray.get`](@ref).
 """
-put(data) = ray_jll.put(to_serialized_buffer(data))
+put(data) = ObjectRef(ray_jll.put(to_serialized_buffer(data)))
 
 """
     Ray.get(object_id::ObjectIDAllocated)
@@ -16,6 +16,7 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
+get(obj_ref::ObjectRef) = _get(ray_jll.get(convert(ray_jll.ObjectID, obj_ref.oid)))
 get(oid::ray_jll.ObjectIDAllocated) = _get(ray_jll.get(oid))
 get(obj::SharedPtr{ray_jll.RayObject}) = _get(ray_jll.GetData(obj[]))
 get(x) = x

--- a/Ray.jl/test/object_ref.jl
+++ b/Ray.jl/test/object_ref.jl
@@ -3,7 +3,7 @@
         hex_str = "f" ^ (2 * 28)
         obj_ref = ObjectRef(hex_str)
         @test obj_ref == ObjectRef(hex_str)
-        @test string(obj_ref) == hex_str
+        @test hex_identifier(obj_ref) == hex_str
     end
 
     @testset "show" begin

--- a/Ray.jl/test/object_ref.jl
+++ b/Ray.jl/test/object_ref.jl
@@ -3,7 +3,7 @@
         hex_str = "f" ^ (2 * 28)
         obj_ref = ObjectRef(hex_str)
         @test obj_ref == ObjectRef(hex_str)
-        @test hex_identifier(obj_ref) == hex_str
+        @test Ray.hex_identifier(obj_ref) == hex_str
     end
 
     @testset "show" begin

--- a/Ray.jl/test/object_ref.jl
+++ b/Ray.jl/test/object_ref.jl
@@ -1,0 +1,20 @@
+@testset "ObjectRef" begin
+    @testset "basic" begin
+        hex_str = "f" ^ (2 * 28)
+        obj_ref = ObjectRef(hex_str)
+        @test obj_ref == ObjectRef(hex_str)
+        @test string(obj_ref) == hex_str
+    end
+
+    @testset "show" begin
+        hex_str = "f" ^ (2 * 28)
+        obj_ref = ObjectRef(hex_str)
+        @test sprint(show, obj_ref) == "ObjectRef(\"$hex_str\")"
+    end
+
+    @testset "convert" begin
+        oid = ray_jll.FromRandom(ray_jll.ObjectID)
+        obj_ref = ObjectRef(oid)
+        @test convert(ray_jll.ObjectID, obj_ref) === oid
+    end
+end

--- a/Ray.jl/test/object_ref.jl
+++ b/Ray.jl/test/object_ref.jl
@@ -7,14 +7,8 @@
     end
 
     @testset "show" begin
-        hex_str = "f" ^ (2 * 28)
+        hex_str = ray_jll.FromRandom(ray_jll.ObjectID)
         obj_ref = ObjectRef(hex_str)
         @test sprint(show, obj_ref) == "ObjectRef(\"$hex_str\")"
-    end
-
-    @testset "convert" begin
-        oid = ray_jll.FromRandom(ray_jll.ObjectID)
-        obj_ref = ObjectRef(oid)
-        @test convert(ray_jll.ObjectID, obj_ref) === oid
     end
 end

--- a/Ray.jl/test/object_ref.jl
+++ b/Ray.jl/test/object_ref.jl
@@ -7,7 +7,7 @@
     end
 
     @testset "show" begin
-        hex_str = ray_jll.FromRandom(ray_jll.ObjectID)
+        hex_str = "f" ^ (2 * 28)
         obj_ref = ObjectRef(hex_str)
         @test sprint(show, obj_ref) == "ObjectRef(\"$hex_str\")"
     end

--- a/Ray.jl/test/object_store.jl
+++ b/Ray.jl/test/object_store.jl
@@ -23,4 +23,11 @@
     @testset "get fallback" begin
         @test Ray.get(123) == 123
     end
+
+    @testset "put object reference" begin
+        obj_ref1 = Ray.put(123)
+        obj_ref2 = Ray.put(obj_ref1)
+        @test obj_ref1 === obj_ref2
+        @test Ray.get(obj_ref1) == Ray.get(obj_ref2)
+    end
 end

--- a/Ray.jl/test/object_store.jl
+++ b/Ray.jl/test/object_store.jl
@@ -3,20 +3,21 @@
     @testset "Put/Get roundtrip for $(typeof(x))" for x in (
         1, 1.23, "hello", (1, 2, 3), [1, 2, 3],
     )
-        oid = Ray.put(x)
-        @test Ray.get(oid) == x
+        obj_ref = Ray.put(x)
+        @test obj_ref isa ObjectRef
+        @test Ray.get(obj_ref) == x
     end
 
     @testset "get same object twice" begin
-        oid = Ray.put(1)
-        @test Ray.get(oid) == 1
-        @test Ray.get(oid) == 1
+        obj_ref = Ray.put(1)
+        @test Ray.get(obj_ref) == 1
+        @test Ray.get(obj_ref) == 1
     end
 
     @testset "get collections of objects" begin
-        oid1 = Ray.put(123)
-        oid2 = Ray.put("hello")
-        @test Ray.get.([oid2, oid1]) == ["hello", 123]
+        obj_ref1 = Ray.put(123)
+        obj_ref2 = Ray.put("hello")
+        @test Ray.get.([obj_ref2, obj_ref1]) == ["hello", 123]
     end
 
     @testset "get fallback" begin

--- a/Ray.jl/test/runtests.jl
+++ b/Ray.jl/test/runtests.jl
@@ -15,6 +15,7 @@ include("utils.jl")
         Aqua.test_all(Ray; ambiguities=false)
     end
 
+    include("object_ref.jl")
     include("runtime_env.jl")
     include("remote_function.jl")
 

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -20,9 +20,9 @@
     @test result == [3, 2, 1]
 
     # error handling
-    oid = submit_task(error, ("AHHHHH",))
+    obj_ref = submit_task(error, ("AHHHHH",))
     try
-        Ray.get(oid)
+        Ray.get(obj_ref)
     catch e
         @test e isa Ray.RayRemoteException
         @test e.captured.ex == ErrorException("AHHHHH")

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -429,7 +429,12 @@ JLCXX_MODULE define_julia_module(jlcxx::Module& mod)
     mod.method("initialize_driver", &initialize_driver);
     mod.method("shutdown_driver", &shutdown_driver);
     mod.method("initialize_worker", &initialize_worker);
-    mod.add_type<ObjectID>("ObjectID");
+
+    // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/common/id.h#L261
+    mod.add_type<ObjectID>("ObjectID")
+        .method("ObjectIDFromHex", &ObjectID::FromHex)
+        .method("ObjectIDFromRandom", &ObjectID::FromRandom)
+        .method("Hex", &ObjectID::Hex);
 
     // enum Language
     mod.add_bits<ray::Language>("Language", jlcxx::julia_type("CppEnum"));

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -136,6 +136,13 @@ function GetCoreWorker()
 end
 
 #####
+##### ObjectID
+#####
+
+FromHex(::Type{ObjectID}, str::AbstractString) = ObjectIDFromHex(str)
+FromRandom(::Type{ObjectID}) = ObjectIDFromRandom()
+
+#####
 ##### Upstream fixes
 #####
 


### PR DESCRIPTION
Introduces the `ObjectRef` Julia object which is the Julian interface for dealing with object references. This is similar to how Python handles things. Having this struct allows us to hide the internals of using C++ `ObjectID`s from users.

Addresses part of #77. Extracted from #67