### PR TITLE
C++ wrapped `put`/`get` work with `RayObject`

### DIFF
--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -8,9 +8,7 @@ function put(data)
     bytes = serialize_to_bytes(data)
     buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
     ray_obj = ray_jll.RayObject(buffer)
-    oid = ray_jll.ObjectID()
-    ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}(), CxxPtr(oid))
-    return oid
+    return ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
 end
 
 """

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -8,7 +8,7 @@ function put(data)
     bytes = serialize_to_bytes(data)
     buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
     ray_obj = ray_jll.RayObject(buffer)
-    return ray_jll.put(ray_obj)
+    return ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
 end
 
 """

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -7,7 +7,8 @@ the `data` with [`Ray.get`](@ref).
 function put(data)
     bytes = serialize_to_bytes(data)
     buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
-    return ray_jll.put(buffer)
+    ray_obj = ray_jll.RayObject(buffer)
+    return ray_jll.put(ray_obj)
 end
 
 """

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -8,7 +8,9 @@ function put(data)
     bytes = serialize_to_bytes(data)
     buffer = ray_jll.LocalMemoryBuffer(bytes, sizeof(bytes), true)
     ray_obj = ray_jll.RayObject(buffer)
-    return ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
+    oid = ray_jll.ObjectID()
+    ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}(), CxxPtr(oid))
+    return oid
 end
 
 """

--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -20,8 +20,8 @@ if run in an `@async` task.
 If the task that generated the `ObjectID` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
-get(oid::ray_jll.ObjectIDAllocated) = _get(take!(ray_jll.get(oid)))
-get(obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(obj[])))
+get(oid::ray_jll.ObjectIDAllocated) = get(ray_jll.get(oid))
+get(ray_obj::SharedPtr{ray_jll.RayObject}) = _get(take!(ray_jll.GetData(ray_obj[])))
 get(x) = x
 
 function _get(bytes)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -228,15 +228,16 @@ function serialize_args(args)
         serialized_arg = serialize_to_bytes(arg)
         serialized_arg_size = sizeof(serialized_arg)
         buffer = ray_jll.LocalMemoryBuffer(serialized_arg, serialized_arg_size, true)
+        ray_obj = ray_jll.RayObject(buffer)
 
         # Inline arguments which are small and if there is room
         task_arg = if (serialized_arg_size <= put_threshold &&
                        serialized_arg_size + total_inlined <= rpc_inline_threshold)
 
             total_inlined += serialized_arg_size
-            ray_jll.TaskArgByValue(ray_jll.RayObject(buffer))
+            ray_jll.TaskArgByValue(ray_obj)
         else
-            oid = ray_jll.put(buffer)
+            oid = ray_jll.put(ray_obj)
             # TODO: Add test for populating `call_site`
             call_site = record_call_site ? sprint(Base.show_backtrace, backtrace()) : ""
             ray_jll.TaskArgByReference(oid, rpc_address, call_site)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -237,8 +237,7 @@ function serialize_args(args)
             total_inlined += serialized_arg_size
             ray_jll.TaskArgByValue(ray_obj)
         else
-            oid = ray_jll.ObjectID()
-            ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}(), CxxPtr(oid))
+            oid = ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
             # TODO: Add test for populating `call_site`
             call_site = record_call_site ? sprint(Base.show_backtrace, backtrace()) : ""
             ray_jll.TaskArgByReference(oid, rpc_address, call_site)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -237,7 +237,8 @@ function serialize_args(args)
             total_inlined += serialized_arg_size
             ray_jll.TaskArgByValue(ray_obj)
         else
-            oid = ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
+            oid = ray_jll.ObjectID()
+            ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}(), CxxPtr(oid))
             # TODO: Add test for populating `call_site`
             call_site = record_call_site ? sprint(Base.show_backtrace, backtrace()) : ""
             ray_jll.TaskArgByReference(oid, rpc_address, call_site)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -237,7 +237,7 @@ function serialize_args(args)
             total_inlined += serialized_arg_size
             ray_jll.TaskArgByValue(ray_obj)
         else
-            oid = ray_jll.put(ray_obj)
+            oid = ray_jll.put(ray_obj, StdVector{ray_jll.ObjectID}())
             # TODO: Add test for populating `call_site`
             call_site = record_call_site ? sprint(Base.show_backtrace, backtrace()) : ""
             ray_jll.TaskArgByReference(oid, rpc_address, call_site)

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -183,12 +183,15 @@ ray::core::CoreWorker &_GetCoreWorker() {
 }
 
 // Example of using `CoreWorker::Put`: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
-void put(const std::shared_ptr<RayObject> object,
-         const std::vector<ObjectID> &contained_object_ids,
-         ObjectID *object_id) {
+ObjectID put(const std::shared_ptr<RayObject> object,
+             const std::vector<ObjectID> &contained_object_ids) {
 
     auto &worker = CoreWorkerProcess::GetCoreWorker();
-    RAY_CHECK_OK(worker.Put(*object, contained_object_ids, object_id));
+
+    // Store our data in the object store
+    ObjectID object_id;
+    RAY_CHECK_OK(worker.Put(*object, contained_object_ids, &object_id));
+    return object_id;
 }
 
 // Example of using `CoreWorker::Get`: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L210-L220

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -183,16 +183,16 @@ ray::core::CoreWorker &_GetCoreWorker() {
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
-void put(std::shared_ptr<RayObject> ray_obj,
-         std::vector<ObjectID> &contained_object_ids,
+void put(const std::shared_ptr<RayObject> object,
+         const std::vector<ObjectID> &contained_object_ids,
          ObjectID *object_id) {
 
     auto &worker = CoreWorkerProcess::GetCoreWorker();
-    RAY_CHECK_OK(worker.Put(*ray_obj, contained_object_ids, object_id));
+    RAY_CHECK_OK(worker.Put(*object, contained_object_ids, object_id));
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L210-L220
-std::shared_ptr<RayObject> get(ObjectID object_id) {
+std::shared_ptr<RayObject> get(const ObjectID object_id) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
     // Retrieve our data from the object store

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -182,7 +182,7 @@ ray::core::CoreWorker &_GetCoreWorker() {
     return CoreWorkerProcess::GetCoreWorker();
 }
 
-// https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
+// Example of using `CoreWorker::Put`: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
 void put(const std::shared_ptr<RayObject> object,
          const std::vector<ObjectID> &contained_object_ids,
          ObjectID *object_id) {
@@ -191,7 +191,7 @@ void put(const std::shared_ptr<RayObject> object,
     RAY_CHECK_OK(worker.Put(*object, contained_object_ids, object_id));
 }
 
-// https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L210-L220
+// Example of using `CoreWorker::Get`: https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L210-L220
 std::shared_ptr<RayObject> get(const ObjectID object_id) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -183,12 +183,12 @@ ray::core::CoreWorker &_GetCoreWorker() {
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
-ObjectID put(std::shared_ptr<RayObject> ray_obj) {
+ObjectID put(std::shared_ptr<RayObject> ray_obj, std::vector<ObjectID> &contained_object_ids) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
     // Store our string in the object store
     ObjectID object_id;
-    RAY_CHECK_OK(worker.Put(*ray_obj, {}, &object_id));
+    RAY_CHECK_OK(worker.Put(*ray_obj, contained_object_ids, &object_id));
 
     return object_id;
 }

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -183,13 +183,12 @@ ray::core::CoreWorker &_GetCoreWorker() {
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
-ObjectID put(std::shared_ptr<Buffer> buffer) {
+ObjectID put(std::shared_ptr<RayObject> ray_obj) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
     // Store our string in the object store
     ObjectID object_id;
-    RayObject ray_obj = RayObject(buffer, nullptr, std::vector<rpc::ObjectReference>());
-    RAY_CHECK_OK(worker.Put(ray_obj, {}, &object_id));
+    RAY_CHECK_OK(worker.Put(*ray_obj, {}, &object_id));
 
     return object_id;
 }

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -196,12 +196,12 @@ std::shared_ptr<RayObject> get(const ObjectID object_id) {
     auto &worker = CoreWorkerProcess::GetCoreWorker();
 
     // Retrieve our data from the object store
-    std::vector<std::shared_ptr<RayObject>> results;
+    std::vector<std::shared_ptr<RayObject>> objects;
     std::vector<ObjectID> get_obj_ids = {object_id};
-    RAY_CHECK_OK(worker.Get(get_obj_ids, -1, &results));
+    RAY_CHECK_OK(worker.Get(get_obj_ids, -1, &objects));
 
-    std::shared_ptr<RayObject> result = results[0];
-    return result;
+    RAY_CHECK(objects.size() == 1);
+    return objects[0];
 }
 
 std::string ToString(ray::FunctionDescriptor function_descriptor)

--- a/deps/wrapper.cc
+++ b/deps/wrapper.cc
@@ -183,14 +183,12 @@ ray::core::CoreWorker &_GetCoreWorker() {
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L224-L237
-ObjectID put(std::shared_ptr<RayObject> ray_obj, std::vector<ObjectID> &contained_object_ids) {
+void put(std::shared_ptr<RayObject> ray_obj,
+         std::vector<ObjectID> &contained_object_ids,
+         ObjectID *object_id) {
+
     auto &worker = CoreWorkerProcess::GetCoreWorker();
-
-    // Store our string in the object store
-    ObjectID object_id;
-    RAY_CHECK_OK(worker.Put(*ray_obj, contained_object_ids, &object_id));
-
-    return object_id;
+    RAY_CHECK_OK(worker.Put(*ray_obj, contained_object_ids, object_id));
 }
 
 // https://github.com/ray-project/ray/blob/ray-2.5.1/src/ray/core_worker/test/core_worker_test.cc#L210-L220

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -22,7 +22,6 @@ using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
 ObjectID put(std::shared_ptr<Buffer> buffer);
-std::shared_ptr<Buffer> get(ObjectID object_id);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.

--- a/deps/wrapper.h
+++ b/deps/wrapper.h
@@ -21,7 +21,6 @@ using ray::core::RayFunction;
 using ray::core::TaskOptions;
 using ray::core::WorkerType;
 
-ObjectID put(std::shared_ptr<Buffer> buffer);
 std::string ToString(ray::FunctionDescriptor function_descriptor);
 
 // a wrapper class to manage the IO service + thread that the GcsClient needs.

--- a/src/wrappers/any.jl
+++ b/src/wrappers/any.jl
@@ -149,11 +149,6 @@ end
 ##### Upstream fixes
 #####
 
-# Works around what appears to be a CxxWrap issue
-function put(buffer::CxxWrap.StdLib.SharedPtr{LocalMemoryBuffer})
-    return put(CxxWrap.CxxWrapCore.__cxxwrap_smartptr_cast_to_base(buffer))
-end
-
 function Base.take!(buffer::CxxWrap.CxxWrapCore.SmartPointer{<:Buffer})
     buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
     buffer_size = Size(buffer[])

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -1,4 +1,6 @@
 using ray_core_worker_julia_jll: put, get
+using ray_core_worker_julia_jll: LocalMemoryBuffer, Data
+using ray_core_worker_julia_jll: RayObject, GetData
 
 @testset "put / get" begin
     @testset "roundtrip vector" begin
@@ -7,7 +9,8 @@ using ray_core_worker_julia_jll: put, get
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
-        buffer = get(obj_ref)
+        ray_obj = get(obj_ref)
+        buffer = GetData(ray_obj[])
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])
         T = eltype(data)
@@ -23,7 +26,8 @@ using ray_core_worker_julia_jll: put, get
         data = "Greetings from Julia!"
         obj_ref = put(LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true))
 
-        buffer = get(obj_ref)
+        ray_obj = get(obj_ref)
+        buffer = GetData(ray_obj[])
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])
         v = Vector{UInt8}(undef, buffer_size)

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -6,11 +6,11 @@ using ray_core_worker_julia_jll: RayObject, GetData
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        obj_ref = put(RayObject(buffer))
+        oid = put(RayObject(buffer))
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
-        ray_obj = get(obj_ref)
+        ray_obj = get(oid)
         buffer = GetData(ray_obj[])
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])
@@ -26,9 +26,9 @@ using ray_core_worker_julia_jll: RayObject, GetData
     @testset "roundtrip string" begin
         data = "Greetings from Julia!"
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        obj_ref = put(RayObject(buffer))
+        oid = put(RayObject(buffer))
 
-        ray_obj = get(obj_ref)
+        ray_obj = get(oid)
         buffer = GetData(ray_obj[])
         buffer_ptr = Ptr{UInt8}(Data(buffer[]).cpp_object)
         buffer_size = Size(buffer[])

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -7,7 +7,8 @@ using ray_core_worker_julia_jll: ObjectID
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = put(RayObject(buffer), StdVector{ObjectID}())
+        oid = ObjectID()
+        put(RayObject(buffer), StdVector{ObjectID}(), CxxPtr(oid))
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
@@ -27,7 +28,8 @@ using ray_core_worker_julia_jll: ObjectID
     @testset "roundtrip string" begin
         data = "Greetings from Julia!"
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = put(RayObject(buffer), StdVector{ObjectID}())
+        oid = ObjectID()
+        put(RayObject(buffer), StdVector{ObjectID}(), CxxPtr(oid))
 
         ray_obj = get(oid)
         buffer = GetData(ray_obj[])

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -5,7 +5,8 @@ using ray_core_worker_julia_jll: RayObject, GetData
 @testset "put / get" begin
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
-        obj_ref = put(LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true))
+        buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+        obj_ref = put(RayObject(buffer))
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
@@ -24,7 +25,8 @@ using ray_core_worker_julia_jll: RayObject, GetData
 
     @testset "roundtrip string" begin
         data = "Greetings from Julia!"
-        obj_ref = put(LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true))
+        buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
+        obj_ref = put(RayObject(buffer))
 
         ray_obj = get(obj_ref)
         buffer = GetData(ray_obj[])

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -1,12 +1,13 @@
 using ray_core_worker_julia_jll: put, get
 using ray_core_worker_julia_jll: LocalMemoryBuffer, Data
 using ray_core_worker_julia_jll: RayObject, GetData
+using ray_core_worker_julia_jll: ObjectID
 
 @testset "put / get" begin
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = put(RayObject(buffer))
+        oid = put(RayObject(buffer), StdVector{ObjectID}())
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
@@ -26,7 +27,7 @@ using ray_core_worker_julia_jll: RayObject, GetData
     @testset "roundtrip string" begin
         data = "Greetings from Julia!"
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = put(RayObject(buffer))
+        oid = put(RayObject(buffer), StdVector{ObjectID}())
 
         ray_obj = get(oid)
         buffer = GetData(ray_obj[])

--- a/test/put_get.jl
+++ b/test/put_get.jl
@@ -7,8 +7,7 @@ using ray_core_worker_julia_jll: ObjectID
     @testset "roundtrip vector" begin
         data = UInt16[1:3;]
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = ObjectID()
-        put(RayObject(buffer), StdVector{ObjectID}(), CxxPtr(oid))
+        oid = put(RayObject(buffer), StdVector{ObjectID}())
 
         # TODO: Currently uses size/length from `data`
         # https://github.com/beacon-biosignals/ray_core_worker_julia_jll.jl/issues/55
@@ -28,8 +27,7 @@ using ray_core_worker_julia_jll: ObjectID
     @testset "roundtrip string" begin
         data = "Greetings from Julia!"
         buffer = LocalMemoryBuffer(Ptr{Nothing}(pointer(data)), sizeof(data), true)
-        oid = ObjectID()
-        put(RayObject(buffer), StdVector{ObjectID}(), CxxPtr(oid))
+        oid = put(RayObject(buffer), StdVector{ObjectID}())
 
         ray_obj = get(oid)
         buffer = GetData(ray_obj[])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using CxxWrap
 using Test
 using ray_core_worker_julia_jll: JuliaFunctionDescriptor, function_descriptor
-using ray_core_worker_julia_jll: get, put
 
 include("utils.jl")
 


### PR DESCRIPTION
Part of the work for #77. In order to specify object IDs contained within an object I needed to update our `put`/`get` wrapped functions. By updating these functions to pass in a `RayObject` these are more inline with the `ray::core::CoreWorker` interface and also allow me to specify the `nested_refs` argument for `RayObject`.