### PR TITLE
Return `ObjectRef` from `submit_task`

### DIFF
--- a/Ray.jl/src/object_store.jl
+++ b/Ray.jl/src/object_store.jl
@@ -14,13 +14,12 @@ end
 put(obj_ref::ObjectRef) = obj_ref
 
 """
-    Ray.get(object_id::ObjectIDAllocated)
+    Ray.get(obj_ref::ObjectRef)
 
-Retrieves the data associated with the `object_id` from the object store.  This
-method is blocking until the data is available in the local object store, even
-if run in an `@async` task.
+Retrieves the data associated with the object reference from the object store. This method
+is blocking until the data is available in the local object store.
 
-If the task that generated the `ObjectID` failed with a Julia exception, the
+If the task that generated the `ObjectRef` failed with a Julia exception, the
 captured exception will be thrown on `get`.
 """
 get(obj_ref::ObjectRef) = get(obj_ref.oid)

--- a/Ray.jl/src/runtime.jl
+++ b/Ray.jl/src/runtime.jl
@@ -195,10 +195,10 @@ function submit_task(f::Function, args::Tuple, kwargs::NamedTuple=NamedTuple();
     end
 
     oid = GC.@preserve task_args begin
-        return ray_jll._submit_task(fd,
-                                    transform_task_args(task_args),
-                                    serialized_runtime_env_info,
-                                    resources)
+        ray_jll._submit_task(fd,
+                             transform_task_args(task_args),
+                             serialized_runtime_env_info,
+                             resources)
     end
     return ObjectRef(oid)
 end

--- a/Ray.jl/test/task.jl
+++ b/Ray.jl/test/task.jl
@@ -1,28 +1,33 @@
 @testset "Submit task" begin
     # single argument
-    result = Ray.get(submit_task(length, ("hello",)))
-    @test result isa Int
-    @test result == 5
+    result = submit_task(length, ("hello",))
+    @test result isa ObjectRef
+    @test Ray.get(result) isa Int
+    @test Ray.get(result) == 5
 
     # multiple arguments
-    result = Ray.get(submit_task(max, (0x00, 0xff)))
-    @test result isa UInt8
-    @test result == 0xff
+    result = submit_task(max, (0x00, 0xff))
+    @test result isa ObjectRef
+    @test Ray.get(result) isa UInt8
+    @test Ray.get(result) == 0xff
 
     # no arguments
-    result = Ray.get(submit_task(getpid, ()))
-    @test result isa Int32
-    @test result > getpid()
+    result = submit_task(getpid, ())
+    @test result isa ObjectRef
+    @test Ray.get(result) isa Int32
+    @test Ray.get(result) > getpid()
 
     # keyword arguments
-    result = Ray.get(submit_task(sort, ([3, 1, 2],), (; rev=true)))
-    @test result isa Vector{Int}
-    @test result == [3, 2, 1]
+    result = submit_task(sort, ([3, 1, 2],), (; rev=true))
+    @test result isa ObjectRef
+    @test Ray.get(result) isa Vector{Int}
+    @test Ray.get(result) == [3, 2, 1]
 
     # error handling
-    obj_ref = submit_task(error, ("AHHHHH",))
+    result = submit_task(error, ("AHHHHH",))
+    @test result isa ObjectRef
     try
-        Ray.get(obj_ref)
+        Ray.get(result)
     catch e
         @test e isa Ray.RayRemoteException
         @test e.captured.ex == ErrorException("AHHHHH")


### PR DESCRIPTION
Mistake introduced in #81.